### PR TITLE
Debug levels independent of util_i_debug

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -47,12 +47,12 @@ int DEBUG_LOGGING = DEBUG_LOG_ALL;
 // a variable on the object called DEBUG_LEVEL within the toolset.  This method
 // will always use the most verbose setting between the object setting and the
 // module setting.  Alternately, you can set a specific debug level on an
-// object and/or an event using SetObjectDebugLevel() and SetEventDebugLevel().
-// Unlike the previous method, you cannot set these as variables in the toolset
-// and the values you set will be used regardless of the module setting chosen
-// below.  If you set a debug level on an object that runs an event which also
-// has a debug level set on it, the most verbose between the two will be used.
-// If neither is set the module setting below will be used.
+// object and/or an event using SetDebugLevel() and SetEventDebugLevel().
+// If an event debug level is set, that setting will be used, regardless of the
+// debug level set on the module or the calling object.  This allows the builder
+// to prevent excess debug logging from verbose events such as OnCreaturePerception.
+// If an object with a debug level set runs an event with a debug level set,
+// the event debug level will be used.
 // Possible values:
 // - DEBUG_LEVEL_CRITICAL: errors severe enough to stop the script
 // - DEBUG_LEVEL_ERROR: indicates the script malfunctioned in some way

--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -42,12 +42,17 @@ const string FALLBACK_DATABASE = "core_framework";
 // - DEBUG_LOG_ALL: debug messages are sent to the log files, DMs, and first PC
 int DEBUG_LOGGING = DEBUG_LOG_ALL;
 
-// This is the level of debug messages to generate. All debug messages of this
-// level or higher will be logged to DEBUG_LOGGING. This is only the default
-// level for the module. You can set a higher level on an object by calling
-// SetDebugLevel() on it. Alternatively, you may use the toolset to add a local
-// int named DEBUG_LEVEL on the object; the value should be 0-3, where a higher
-// value means higher verbosity.
+// This is the level of debug messages to generate.  You can set a higher level
+// on a specific object by calling SetDebugLevel() on that object or by setting
+// a variable on the object called DEBUG_LEVEL within the toolset.  This method
+// will always use the most verbose setting between the object setting and the
+// module setting.  Alternately, you can set a specific debug level on an
+// object and/or an event using SetObjectDebugLevel() and SetEventDebugLevel().
+// Unlike the previous method, you cannot set these as variables in the toolset
+// and the values you set will be used regardless of the module setting chosen
+// below.  If you set a debug level on an object that runs an event which also
+// has a debug level set on it, the most verbose between the two will be used.
+// If neither is set the module setting below will be used.
 // Possible values:
 // - DEBUG_LEVEL_CRITICAL: errors severe enough to stop the script
 // - DEBUG_LEVEL_ERROR: indicates the script malfunctioned in some way

--- a/src/core/core_i_constants.nss
+++ b/src/core/core_i_constants.nss
@@ -72,6 +72,12 @@ const float  EVENT_PRIORITY_LAST    =  -9999.0;         // The script is always 
 const float  EVENT_PRIORITY_ONLY    =  11111.0;         // The script will be the only one to execute
 const float  EVENT_PRIORITY_DEFAULT = -11111.0;         // The script will only execute if no other scripts do
 
+const string EVENT_DEBUG            = "EVENT_DEBUG";        //Used for setting custom event
+const string EVENT_DEBUG_SET        = "EVENT_DEBUG_SET";    // and object debug levels
+const string OBJECT_DEBUG           = "OBJECT_DEBUG";
+const string OBJECT_DEBUG_SET       = "OBJECT_DEBUG_SET";
+const string DEBUG_LEVEL_SUBVERTED  = "DEBUG_LEVEL_SUBVERTED";
+
 // ----- Timer Management ------------------------------------------------------
 
 const string TIMER_EXISTS     = "TIMER_EXISTS";     // Denotes that a timer with the given ID exists

--- a/src/core/core_i_constants.nss
+++ b/src/core/core_i_constants.nss
@@ -72,11 +72,9 @@ const float  EVENT_PRIORITY_LAST    =  -9999.0;         // The script is always 
 const float  EVENT_PRIORITY_ONLY    =  11111.0;         // The script will be the only one to execute
 const float  EVENT_PRIORITY_DEFAULT = -11111.0;         // The script will only execute if no other scripts do
 
-const string EVENT_DEBUG            = "EVENT_DEBUG";        //Used for setting custom event
-const string EVENT_DEBUG_SET        = "EVENT_DEBUG_SET";    // and object debug levels
-const string OBJECT_DEBUG           = "OBJECT_DEBUG";
-const string OBJECT_DEBUG_SET       = "OBJECT_DEBUG_SET";
-const string DEBUG_LEVEL_SUBVERTED  = "DEBUG_LEVEL_SUBVERTED";
+const string EVENT_DEBUG            = "EVENT_DEBUG";    
+const string EVENT_DEBUG_SET        = "EVENT_DEBUG_SET";    
+const string DEBUG_LEVEL_OLD        = "DEBUG_LEVEL_OLD";
 
 // ----- Timer Management ------------------------------------------------------
 

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -385,6 +385,19 @@ int GetIsTimerInfinite(int nTimerID);
 // indefinitely, so be sure to check for this with GetIsTimerInfinite().
 int GetTimerRemaining(int nTimerID);
 
+// ----- Miscellaneous ---------------------------------------------------------
+// ---< ToggleModuleDebugLevel >---
+// ---< core_i_framework >---
+// If a nLevel is passed, that level is set as the primary module level.  If not,
+// the module's debug level is reset to the configurable level set in
+// core_c_config.  The purpose of this function is to allow an event debug level
+// to take primacy over all other debug levels (module and/or object).  If an
+// event debug level is not set, this function is not called and the more verbose
+// of the object debug level or the module debug level is used.
+void ToggleModuleDebugLevel(int nLevel = -1);
+
+
+
 // -----------------------------------------------------------------------------
 //                             Function Definitions
 // -----------------------------------------------------------------------------

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -1033,12 +1033,14 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
     int nEventLevel, nObjectLevel;
 
     // Set the debugging level specific to this event, if it is defined.
-    // This is done by temporarily overriding the object's debug level.
-    if ((nEventLevel = GetEventDebugLevel(sEvent)) != -1 &&
-        nEventLevel > (nObjectLevel = GetDebugLevel(oSelf)))
+    // If an event has a debug level set, we use that debug level, no
+    //  matter what it is.  If an object has a debug level, we use the
+    //  greater of the module or the object.
+    if ((nEventLevel = GetEventDebugLevel(sEvent)) != -1)
     {
         SetLocalInt(oSelf, DEBUG_LEVEL_OLD, nObjectLevel);
         SetDebugLevel(oSelf, nEventLevel);
+        ToggleModuleDebugLevel(nEventLevel);
     }
 
     Debug("Running " + (bLocalOnly ? "local " : "") + "event " + sEvent +
@@ -1122,6 +1124,8 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
     // If we previously overwrote the object's debug level, reset it.
     if (nObjectLevel = GetLocalInt(oSelf, DEBUG_LEVEL_OLD))
         SetDebugLevel(oSelf, nObjectLevel);
+    
+    ToggleModuleDebugLevel();
 
     DeleteLocalString(oEvent, EVENT_CURRENT_PLUGIN);
     return nState;
@@ -1336,4 +1340,15 @@ int GetTimerRemaining(int nTimerID)
 
     string sTimerID = IntToString(nTimerID);
     return GetLocalInt(TIMERS, TIMER_REMAINING + IntToString(nTimerID));
+}
+
+// ----- Miscellaneous ------------------------------------------------------
+void ToggleModuleDebugLevel(int nLevel = -1)
+{
+    object oModule = GetModule();
+
+    if (nLevel = -1)
+        SetDebugLevel(oModule, DEFAULT_DEBUG_LEVEL);
+    else
+        SetDebugLevel(oModule, nLevel);
 }

--- a/src/hooks/hook_area03.nss
+++ b/src/hooks/hook_area03.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(AREA_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(AREA_EVENT_ON_HEARTBEAT);
 }

--- a/src/hooks/hook_creature07.nss
+++ b/src/hooks/hook_creature07.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(CREATURE_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(CREATURE_EVENT_ON_HEARTBEAT);
 }

--- a/src/hooks/hook_door06.nss
+++ b/src/hooks/hook_door06.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(DOOR_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(DOOR_EVENT_ON_HEARTBEAT);
 }

--- a/src/hooks/hook_encounter04.nss
+++ b/src/hooks/hook_encounter04.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(ENCOUNTER_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(ENCOUNTER_EVENT_ON_HEARTBEAT);
 }

--- a/src/hooks/hook_module06.nss
+++ b/src/hooks/hook_module06.nss
@@ -12,7 +12,7 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(MODULE_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(MODULE_EVENT_ON_HEARTBEAT);
 
     if (ENABLE_ON_HOUR_EVENT)

--- a/src/hooks/hook_placeable05.nss
+++ b/src/hooks/hook_placeable05.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(PLACEABLE_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(PLACEABLE_EVENT_ON_HEARTBEAT);
 }

--- a/src/hooks/hook_trigger04.nss
+++ b/src/hooks/hook_trigger04.nss
@@ -12,6 +12,6 @@
 
 void main()
 {
-    SetEventDebugLevel(HEARTBEAT_DEBUG_LEVEL);
+    SetEventDebugLevel(TRIGGER_EVENT_ON_HEARTBEAT, HEARTBEAT_DEBUG_LEVEL);
     RunEvent(TRIGGER_EVENT_ON_HEARTBEAT);
 }

--- a/src/utils/util_i_csvlists.nss
+++ b/src/utils/util_i_csvlists.nss
@@ -65,7 +65,7 @@ string GetListItem(string sList, int nNth = 0);
 // ---< util_i_csvlists >---
 // Returns the item number of sListItem in the CSV list sList. Returns -1 if
 // sListItem is not in the list.
-int FindListItem(string sList, string sListItem);
+int FindListItem(string sList, string sListItem, int nParsed = 0);
 
 // ---< HasListItem >---
 // ---< util_i_csvlists >---
@@ -201,7 +201,7 @@ string GetListItem(string sList, int nNth = 0)
     return TrimString(sList);
 }
 
-int FindListItem(string sList, string sListItem)
+int FindListItem(string sList, string sListItem, int nParsed = 0)
 {
     // Sanity check.
     if (sList == "" || sListItem == "") return -1;
@@ -215,11 +215,11 @@ int FindListItem(string sList, string sListItem)
 
     // Make sure it's not a partial match.
     if (GetListItem(sList, i) == sListItem)
-        return i;
+        return i + nParsed;
 
     // Okay, so let's slim down the list and re-execute.
     string sParsed = StringParse(sList, GetListItem(sList, ++i));
-    return FindListItem(StringRemoveParsed(sList, sParsed), sListItem);
+    return FindListItem(StringRemoveParsed(sList, sParsed), sListItem, i + nParsed);
 }
 
 int HasListItem(string sList, string sListItem)


### PR DESCRIPTION
After a few iterations of this, I discovered that I couldn't really subvert the debug levels independently of temporarily changing the module debug level because of the way the `Debug()` function (and the functions it calls) worked.  To get around that, I added new methodology for a builder to specify object and event debug levels independent of the module level.  Of course, you can still use the original method to get the higher comparative verbosity level.  If you use the new method (`SetObjectDebugLevel()` and/or `SetEventDebugLevel()`), it will use the specific level regardless of the module's level.  As before, this compiles, but was not live-tested.  Also this branch was created from the 1bdced3 commit, so none of the changes from PR #5 are in it, thus restoring util_i_debug to the original file.