### PR TITLE
OnAreaEmpty

### DIFF
--- a/src/core/core_i_constants.nss
+++ b/src/core/core_i_constants.nss
@@ -74,25 +74,29 @@ const float  EVENT_PRIORITY_DEFAULT = -11111.0;         // The script will only 
 
 // ----- Timer Management ------------------------------------------------------
 
-const string TIMER_EXISTS     = "TIMER_EXISTS";     // Denotes that a timer with the given ID exists
-const string TIMER_INTERVAL   = "TIMER_INTERVAL";   // The interval between execution of the timer's script
-const string TIMER_ITERATIONS = "TIMER_ITERATIONS"; // The number of times the timer will run
-const string TIMER_JITTER     = "TIMER_JITTER";     // An amount of variance on the timer's delay
-const string TIMER_NEXT_ID    = "TIMER_NEXT_ID";    // The ID for the next timer
-const string TIMER_REMAINING  = "TIMER_REMAINING";  // The number of iterations remaining
-const string TIMER_RUNNING    = "TIMER_RUNNING";    // Whether the timer is currently running
-const string TIMER_EVENT      = "TIMER_EVENT";      // The event to execute when the timer elapses
-const string TIMER_TARGET     = "TIMER_TARGET";     // The object on which the timer's script will run
-const string TIMER_TARGETS_PC = "TIMER_TARGETS_PC"; // Whether the timer's target is a PC
-const string TIMER_LAST       = "TIMER_LAST";       // The ID of the last timer to run
+const string TIMER_EXISTS        = "TIMER_EXISTS";     // Denotes that a timer with the given ID exists
+const string TIMER_INTERVAL      = "TIMER_INTERVAL";   // The interval between execution of the timer's script
+const string TIMER_ITERATIONS    = "TIMER_ITERATIONS"; // The number of times the timer will run
+const string TIMER_JITTER        = "TIMER_JITTER";     // An amount of variance on the timer's delay
+const string TIMER_NEXT_ID       = "TIMER_NEXT_ID";    // The ID for the next timer
+const string TIMER_REMAINING     = "TIMER_REMAINING";  // The number of iterations remaining
+const string TIMER_RUNNING       = "TIMER_RUNNING";    // Whether the timer is currently running
+const string TIMER_EVENT         = "TIMER_EVENT";      // The event to execute when the timer elapses
+const string TIMER_TARGET        = "TIMER_TARGET";     // The object on which the timer's script will run
+const string TIMER_TARGETS_PC    = "TIMER_TARGETS_PC"; // Whether the timer's target is a PC
+const string TIMER_LAST          = "TIMER_LAST";       // The ID of the last timer to run
+
+const string TIMER_ON_AREA_EMPTY = "TIMER_ON_AREA_EMPTY";   // Timer variable name for OnAreaExit Timer
 
 // ----- Player Management -----------------------------------------------------
 
 const string PC_CD_KEY         = "PC_CD_KEY";
 const string PC_PLAYER_NAME    = "PC_PLAYER_NAME";
-const string PLAYERS_IN_MODULE = "PLAYERS_IN_MODULE";
+const string PLAYER_ROSTER     = "PLAYER_ROSTER";
+const string DM_ROSTER         = "DM_ROSTER";
 const string LOGIN_BOOT        = "LOGIN_BOOT";
 const string LOGIN_DEATH       = "LOGIN_DEATH";
+const string AREA_ROSTER       = "AREA_ROSTER";
 
 // ----- Miscellaneous ---------------------------------------------------------
 
@@ -135,6 +139,9 @@ const string AREA_EVENT_ON_ENTER                      = "OnAreaEnter";
 const string AREA_EVENT_ON_EXIT                       = "OnAreaExit";
 const string AREA_EVENT_ON_HEARTBEAT                  = "OnAreaHeartbeat";
 const string AREA_EVENT_ON_USER_DEFINED               = "OnAreaUserDefined";
+
+// These are pseudo-events called by the Core Framework
+const string AREA_EVENT_ON_EMPTY                      = "OnAreaEmpty";
 
 // ----- Area of Effect Events -------------------------------------------------
 

--- a/src/hooks/hook_area01.nss
+++ b/src/hooks/hook_area01.nss
@@ -12,13 +12,22 @@
 
 void main()
 {
-    // Don't run this event if the entering object is a PC that is about to be
-    // booted.
     object oPC = GetEnteringObject();
-    WriteTimestampedLogEntry(GetName(OBJECT_SELF) + " entered by " + GetName(oPC));
 
-    if (GetIsPC(oPC) && GetLocalInt(oPC, LOGIN_BOOT))
-        return;
+    if (GetIsPC(oPC))
+    {
+        if (GetLocalInt(oPC, LOGIN_BOOT))
+            return;
+
+        if (ENABLE_ON_AREA_EMPTY_EVENT)
+        {
+            int nTimerID = GetLocalInt(OBJECT_SELF, TIMER_ON_AREA_EMPTY);
+            if (GetIsTimerValid(nTimerID))
+                KillTimer(nTimerID);
+        }
+
+        AddListObject(OBJECT_SELF, oPC, AREA_ROSTER, TRUE);
+    }
 
     RunEvent(AREA_EVENT_ON_ENTER, oPC);
     AddScriptSource(oPC);

--- a/src/hooks/hook_area02.nss
+++ b/src/hooks/hook_area02.nss
@@ -15,8 +15,20 @@ void main()
     // Don't run this event if the exiting object is a PC that is about to be
     // booted.
     object oPC = GetExitingObject();
-    if (GetIsPC(oPC) && GetLocalInt(oPC, LOGIN_BOOT))
-        return;
+
+    if (HasListObject(OBJECT_SELF, oPC, AREA_ROSTER))
+    {
+        if (GetLocalInt(oPC, LOGIN_BOOT))
+            return;
+
+        if (!RemoveListObject(OBJECT_SELF, oPC, AREA_ROSTER) 
+                && ENABLE_ON_AREA_EMPTY_EVENT
+                && !CountObjectList(OBJECT_SELF, AREA_ROSTER))
+        {
+            int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
+            StartTimer(nTimerID, FALSE);
+        }
+    }  
 
     RemoveScriptSource(oPC);
     RunEvent(AREA_EVENT_ON_EXIT, oPC);

--- a/src/hooks/hook_area02.nss
+++ b/src/hooks/hook_area02.nss
@@ -16,19 +16,14 @@ void main()
     // booted.
     object oPC = GetExitingObject();
 
-    if (HasListObject(OBJECT_SELF, oPC, AREA_ROSTER))
-    {
-        if (GetLocalInt(oPC, LOGIN_BOOT))
-            return;
+    if (GetIsPC(oPC) && GetLocalInt(oPC, LOGIN_BOOT))
+        return;
 
-        if (!RemoveListObject(OBJECT_SELF, oPC, AREA_ROSTER) 
-                && ENABLE_ON_AREA_EMPTY_EVENT
-                && !CountObjectList(OBJECT_SELF, AREA_ROSTER))
-        {
-            int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
-            StartTimer(nTimerID, FALSE);
-        }
-    }  
+    if (!RemoveListObject(OBJECT_SELF, oPC, AREA_ROSTER) && ENABLE_ON_AREA_EMPTY_EVENT)
+    {
+        int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
+        StartTimer(nTimerID, FALSE);
+    }
 
     RemoveScriptSource(oPC);
     RunEvent(AREA_EVENT_ON_EXIT, oPC);

--- a/src/hooks/hook_module03.nss
+++ b/src/hooks/hook_module03.nss
@@ -35,13 +35,13 @@ void main()
         // correctly execute for him.
         DeleteLocalInt(oPC, LOGIN_BOOT);
 
-        if (!GetIsDM(oPC))
-        {
-            // This is a running count of the number of players in the module.
-            // It will not count DMs. This is a handy utility for counting
-            // online players.
-            AddListObject(OBJECT_SELF, oPC, PLAYERS_IN_MODULE, TRUE);
-        }
+        // This is a running count of the number of players in the module.
+        // It will count DMs separately. This is a handy utility for counting
+        // online players.
+        if (GetIsDM(oPC))
+            AddListObject(OBJECT_SELF, oPC, DM_ROSTER, TRUE);
+        else if (GetIsPC(oPC))
+            AddListObject(OBJECT_SELF, oPC, PLAYER_ROSTER, TRUE);
 
         // Send the player the welcome message.
         DelayCommand(1.0, SendMessageToPC(oPC, WELCOME_MESSAGE));

--- a/src/hooks/hook_module04.nss
+++ b/src/hooks/hook_module04.nss
@@ -20,7 +20,9 @@ void main()
         RunEvent(MODULE_EVENT_ON_CLIENT_LEAVE);
 
         // Decrement the count of players in the module
-        if (!GetIsDM(oPC))
-            RemoveListObject(OBJECT_SELF, oPC, PLAYERS_IN_MODULE);
+        if (GetIsDM(oPC))
+            RemoveListObject(OBJECT_SELF, oPC, DM_ROSTER);
+        else if (GetIsPC(oPC))
+            RemoveListObject(OBJECT_SELF, oPC, PLAYER_ROSTER);
     }
 }


### PR DESCRIPTION
We discussed this on discord a few times, but just realized it was never implemented.  Here's the code we discussed, along with a few other minor modifications for rostering/player management.  The modification from our discord discussion allows the Area Roster to be used even if the builder does not allow the OnAreaEmpty event.

* Adds a DM roster, in addition to the Area and Player rosters.
* Adds OnAreaEmpty timer functions
* Adds appropriate constants to make above work.

Feedback welcome.