### PR TITLE
Timers

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -1110,6 +1110,9 @@ int CreateTimer(object oTarget, string sEvent, float fInterval, int nIterations 
     }
 
     int nTimerID = GetLocalInt(TIMERS, TIMER_NEXT_ID);
+    if (!nTimer)
+        nTimer = 1;
+
     string sTimerID = IntToString(nTimerID);
 
     SetLocalString(TIMERS, TIMER_EVENT       + sTimerID, sEvent);
@@ -1159,6 +1162,7 @@ void _TimerElapsed(int nTimerID, int bFirstRun = FALSE)
     {
         Debug("Cannot execute timer " + sEvent + ": " + sError, DEBUG_LEVEL_WARNING);
         KillTimer(nTimerID);
+        return;
     }
 
     // Check how many more times the timer should be run
@@ -1243,6 +1247,8 @@ void ResetTimer(int nTimerID)
 void KillTimer(int nTimerID)
 {
     string sTimerID = IntToString(nTimerID);
+
+    Debug("Killing timer with ID=" + sTimerID);
 
     // Cleanup the local variables
     DeleteLocalString(TIMERS, TIMER_EVENT       + sTimerID);

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -1110,8 +1110,8 @@ int CreateTimer(object oTarget, string sEvent, float fInterval, int nIterations 
     }
 
     int nTimerID = GetLocalInt(TIMERS, TIMER_NEXT_ID);
-    if (!nTimer)
-        nTimer = 1;
+    if (!nTimerID)
+        nTimerID = 1;
 
     string sTimerID = IntToString(nTimerID);
 


### PR DESCRIPTION
Finally got a functioning module put together and started testing, only to have various timers wreaking havoc with referencing the wrong timer and causing infinite loops.

Here's the issues:  

Infinite loop on dead timer:  killed timers are attempting to run infinitely at 0 second intervals, causing infinite loops, TMI and a frozen executable.  When a timer is killed, the variables are removed, but the countdown continues until `_TimerElapsed()` is called (this is expected behavior).  However, when `_TimerElapsed()` discovers the the timer is dead and throws an error, it doesn't quit the function, but continues, resets `nIterations` to `0` (via `KillTimer()` which deletes the variable) and attempts to run infinitely (because `nIterations = 0 = infinite`).  This is caused by lack of a `return;` after an error is discovered in `_TimerElapsed`.  

Referencing incorrect timer:  the first timer created by the system has `ID=0`.  When checking to see if a timerID variable exists on an object, `0` is returned if the variable doesn't exist.  Since there is no way to know if that's a valid ID or a lack of ID, I can't definitely determine whether the timer is valid or not. Additionally, in `CreateTimer()`, `0` is returned if there is an error creating the timer, so I may think there is a valid timer (because `0` is a valid ID) when the timer was never created.  This specific error condition can be gotten around with a `TIMER_EXISTS` check (or possibly changing the error result to -1), however the other condition cannot be checked.  I resolved this issue by forcing the first timer ID to be `1` instead of `0`.  This also allows a return of `0` to show a valid error condition without checking `TIMER_EXISTS`.  That's probably all about as clear as mud.

These two minor changes resolves all the issues I was having with timers.  The next is just a dress-up addition.  Feedback welcome.

Other:
Added a `Debug()` statement in `KillTimer()` so it logs when timers are killed.