### PR TITLE
area empty event bypass

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -840,6 +840,18 @@ void DumpEventScripts(object oTarget, string sEvent)
     }
 }
 
+int HasEventScripts(string sEvent, object oSelf = OBJECT_SELF)
+{
+    object oEvent;
+
+    if (GetLocalInt(oSelf, sEvent))
+        oEvent = GetDataItem(EVENTS, sEvent);
+    else
+        oEvent = InitializeEvent(sEvent, oSelf, oSelf);
+
+    return CountStringList(oEvent, sEvent);
+}
+
 object GetEvent(string sEvent)
 {
     object oEvent = GetDataItem(EVENTS, sEvent);

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -246,6 +246,12 @@ void SortEventScripts(object oTarget, string sEvent);
 // Prints all scripts registered to oTarget for sEvent as debug output.
 void DumpEventScripts(object oTarget, string sEvent);
 
+// ---< CountEventScripts >---
+// ---< core_i_framework >---
+// Returns the number of event scripts assigned to sEvent on oSelf.  The
+// event will be initialized if required.
+int CountEventScripts(string sEvent, object oSelf = OBJECT_SELF);
+
 // ---< GetEvent >---
 // ---< core_i_framework >---
 // Returns an object representing sEvent, creating it if it does not already
@@ -840,7 +846,7 @@ void DumpEventScripts(object oTarget, string sEvent)
     }
 }
 
-int HasEventScripts(string sEvent, object oSelf = OBJECT_SELF)
+int CountEventScripts(string sEvent, object oSelf = OBJECT_SELF)
 {
     object oEvent;
 

--- a/src/hooks/hook_area02.nss
+++ b/src/hooks/hook_area02.nss
@@ -21,7 +21,7 @@ void main()
 
     if (!RemoveListObject(OBJECT_SELF, oPC, AREA_ROSTER) && ENABLE_ON_AREA_EMPTY_EVENT)
     {
-        if (HasEventScripts(AREA_EVENT_ON_EMPTY))
+        if (CountEventScripts(AREA_EVENT_ON_EMPTY))
         {
             int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
             StartTimer(nTimerID, FALSE);

--- a/src/hooks/hook_area02.nss
+++ b/src/hooks/hook_area02.nss
@@ -21,8 +21,11 @@ void main()
 
     if (!RemoveListObject(OBJECT_SELF, oPC, AREA_ROSTER) && ENABLE_ON_AREA_EMPTY_EVENT)
     {
-        int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
-        StartTimer(nTimerID, FALSE);
+        if (HasEventScripts(AREA_EVENT_ON_EMPTY))
+        {
+            int nTimerID = CreateTimer(OBJECT_SELF, AREA_EVENT_ON_EMPTY, ON_AREA_EMPTY_EVENT_DELAY, 1);
+            StartTimer(nTimerID, FALSE);
+        }
     }
 
     RemoveScriptSource(oPC);


### PR DESCRIPTION
Finally got around to this.  Went back and forth on how best to implement this and I think it has the most potential use in this form factor.  I opted for `InitializeEvent()` since that had to be accomplished anyway and ensures we we're looking for local events also (might have this logic wrong).  Subsequent runs access the `oEvent` object directly for quicker access times.  Adding the `HasEventScripts` allows for other functions to access it as well as cleaning up the hook script a little.