### PR TITLE
Added constants, assignment.

### DIFF
--- a/src/core/core_i_constants.nss
+++ b/src/core/core_i_constants.nss
@@ -98,6 +98,8 @@ const string DM_ROSTER         = "DM_ROSTER";
 const string LOGIN_BOOT        = "LOGIN_BOOT";
 const string LOGIN_DEATH       = "LOGIN_DEATH";
 const string AREA_ROSTER       = "AREA_ROSTER";
+const string IS_PC             = "IS_PC";
+const string IS_DM             = "IS_DM";
 
 // ----- Miscellaneous ---------------------------------------------------------
 

--- a/src/hooks/hook_module03.nss
+++ b/src/hooks/hook_module03.nss
@@ -39,9 +39,15 @@ void main()
         // It will count DMs separately. This is a handy utility for counting
         // online players.
         if (GetIsDM(oPC))
+        {    
             AddListObject(OBJECT_SELF, oPC, DM_ROSTER, TRUE);
+            SetLocalInt(oPC, IS_DM, TRUE);
+        }
         else if (GetIsPC(oPC))
+        {
             AddListObject(OBJECT_SELF, oPC, PLAYER_ROSTER, TRUE);
+            SetLocalInt(oPC, IS_PC, TRUE);
+        }
 
         // Send the player the welcome message.
         DelayCommand(1.0, SendMessageToPC(oPC, WELCOME_MESSAGE));


### PR DESCRIPTION
`GetWasPC()` referenced a non-existent constant (`IS_PC`).  Added that constand (and `IS_DM` for consistency, even though not currently used) to `core_i_const`.  Added assignment of `IS_DM` and `IS_PC` to `oPC` objects OCE in `hook_module03`.