### PR TITLE
fixed changed event sources not firing scripts

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -982,7 +982,11 @@ object InitializeEvent(string sEvent, object oSelf, object oInit)
     // Check if we've added new event sources since the last time we executed
     // this event on oSelf.
     if (GetEventSourcesChanged(oSelf, oSources, sEvent))
+    {
         CacheEventSources(oSelf, oSources, sEvent);
+        DeleteLocalInt(oSelf, sEvent);
+        Debug("Event sources for " + sEvent + " on " + GetName(oSelf) + " have changed; re-initializing event");
+    }
 
     // Do initial setup if it hasn't been done or if the script list has
     // been changed.

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -984,8 +984,7 @@ object InitializeEvent(string sEvent, object oSelf, object oInit)
     if (GetEventSourcesChanged(oSelf, oSources, sEvent))
     {
         CacheEventSources(oSelf, oSources, sEvent);
-        DeleteLocalInt(oSelf, sEvent);
-        Debug("Event sources for " + sEvent + " on " + GetName(oSelf) + " have changed; re-initializing event");
+        Debug("Event sources for " + sEvent + " on " + GetName(oSelf) + " have changed; re-initializing");
     }
 
     // Do initial setup if it hasn't been done or if the script list has


### PR DESCRIPTION
We found specific scripts were not being run when they were added via `AddScriptSource` in `core_i_framework`.  Maybe not the best way to ensure they run, but this modification resets the variables that marks the scripts as collected, forcing them to recollect them from the script sources, thus allowing newly-added script sources to provide their scripts to the framework.