### PR TITLE
add aoe hook scripts

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -185,6 +185,11 @@ const float ON_AREA_EMPTY_EVENT_DELAY = 180.0;
 //                                 Miscellaneous
 // -----------------------------------------------------------------------------
 
+// When using AOE hook scripts, NPCs can be added to the AOE roster for easier
+// access during scripting.  To only allow PC objects on the AOE rosters, set
+// this to FALSE.
+const int INCLUDE_NPC_IN_AOE_ROSTER = TRUE;
+
 // This is the welcome message that will be sent to all players and DMs that log
 // into the module.
 const string WELCOME_MESSAGE = "Welcome to the Core Framework.";

--- a/src/core/core_i_constants.nss
+++ b/src/core/core_i_constants.nss
@@ -98,6 +98,7 @@ const string DM_ROSTER         = "DM_ROSTER";
 const string LOGIN_BOOT        = "LOGIN_BOOT";
 const string LOGIN_DEATH       = "LOGIN_DEATH";
 const string AREA_ROSTER       = "AREA_ROSTER";
+const string AOE_ROSTER        = "AOE_ROSTER";
 const string IS_PC             = "IS_PC";
 const string IS_DM             = "IS_DM";
 
@@ -151,6 +152,9 @@ const string AREA_EVENT_ON_EMPTY                      = "OnAreaEmpty";
 const string AOE_EVENT_ON_ENTER                       = "OnAoEEnter";
 const string AOE_EVENT_ON_EXIT                        = "OnAoEExit";
 const string AOE_EVENT_ON_HEARTBEAT                   = "OnAoEHeartbeat";
+
+// These are pseudo-events called by the Core Framework
+const string AOE_EVENT_ON_EMPTY                       = "OnAoEEmpty";
 
 // ----- Creature Events -------------------------------------------------------
 

--- a/src/hooks/hook_aoe01.nss
+++ b/src/hooks/hook_aoe01.nss
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------------
+//    File: hook_aoe01.nss
+//  System: Core Framework (event script)
+//     URL: https://github.com/squattingmonk/nwn-core-framework
+// Authors: Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
+// -----------------------------------------------------------------------------
+// AOE OnEnter event script.
+// -----------------------------------------------------------------------------
+
+#include "core_i_framework"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+
+    if (INCLUDE_NPC_IN_AOE_ROSTER || GetIsPC(oPC))
+        AddListObject(OBJECT_SELF, oPC, AOE_ROSTER, TRUE);
+
+    RunEvent(AOE_EVENT_ON_ENTER, oPC);
+}

--- a/src/hooks/hook_aoe02.nss
+++ b/src/hooks/hook_aoe02.nss
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------------
+//    File: hook_aoe02.nss
+//  System: Core Framework (event script)
+//     URL: https://github.com/squattingmonk/nwn-core-framework
+// Authors: Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
+// -----------------------------------------------------------------------------
+// AOE OnHeartbeat event script.
+// -----------------------------------------------------------------------------
+
+#include "core_i_framework"
+
+void main()
+{
+    RunEvent(AOE_EVENT_ON_HEARTBEAT);
+}

--- a/src/hooks/hook_aoe03.nss
+++ b/src/hooks/hook_aoe03.nss
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------------
+//    File: hook_aoe03.nss
+//  System: Core Framework (event script)
+//     URL: https://github.com/squattingmonk/nwn-core-framework
+// Authors: Michael A. Sinclair (Squatting Monk) <squattingmonk@gmail.com>
+// -----------------------------------------------------------------------------
+// AOE OnExit event script.
+// -----------------------------------------------------------------------------
+
+#include "core_i_framework"
+
+void main()
+{
+    object oPC = GetExitingObject();
+
+    if (INCLUDE_NPC_IN_AOE_ROSTER || GetIsPC(oPC))
+        RemoveListObject(OBJECT_SELF, oPC, AOE_ROSTER);
+
+    int nState = RunEvent(AOE_EVENT_ON_EXIT, oPC);
+    
+    if (!(nState & EVENT_STATE_ABORT))
+    {
+        if (!CountObjectList(OBJECT_SELF, AOE_ROSTER))
+            RunEvent(AOE_EVENT_ON_EMPTY);
+    }
+}


### PR DESCRIPTION
This PR adds in hook scripts for AOE events.  When creating an AOE, to allow the framework to manipulate the events, it should be created like this:
```c
effect eAOE = EffectAreaOfEffect(AOE_PER_CUSTOM_AOE, "hook_aoe01", "hook_aoe02", "hook_aoe03");
```
Scripters can then assign global or local scripts as desired, just as with any other events.  AOE hook scripts create "AOE Rosters", just like the framework's DM Roster and Player Roster.  This allows builders to easily loop through all objects in the AOE to provide desired effects.  Including NPCs in the AOE Roster is optional and can be set in `core_i_config`.

`hook_aoe03` allows for an  `AoEOnEmpty` event when the last object departs the AOE.