### PR TITLE
added framework initialization debug setting

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -100,6 +100,13 @@ const int HEARTBEAT_DEBUG_LEVEL = DEBUG_LEVEL_ERROR;
 // - DEBUG_LEVEL_DEBUG: data dumps used for debugging
 const int PERCEPTION_DEBUG_LEVEL = DEBUG_LEVEL_ERROR;
 
+// This is the level of debug messages to generate when the framework is
+// initializing.  To prevent excessive logging during initialization, set
+// this to a lower level than DEFAULT_DEBUG_LEVEL above.  Once framework
+// initialization is complete, module debug level will revert to
+// DEFAULT_DEBUG_LEVEL
+const int INITIALIZATION_DEBUG_LEVEL = DEBUG_LEVEL_DEBUG;
+
 // -----------------------------------------------------------------------------
 //                         Library and Plugin Management
 // -----------------------------------------------------------------------------

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -417,7 +417,7 @@ void InitializeCoreFramework()
     SetLocalInt(oModule, CORE_INITIALIZED, TRUE);
 
     // Start debugging
-    SetDebugLevel(DEFAULT_DEBUG_LEVEL, oModule);
+    SetDebugLevel(INITIALIZATION_DEBUG_LEVEL, oModule);
     SetDebugLogging(DEBUG_LOGGING);
 
     // Set specific event debug levels
@@ -445,6 +445,7 @@ void InitializeCoreFramework()
     LoadLibraries(INSTALLED_LIBRARIES);
     LoadPlugins(INSTALLED_PLUGINS);
 
+    SetDebugLevel(DEFAULT_DEBUG_LEVEL, oModule);
     Debug("Successfully initialized Core Framework");
 }
 


### PR DESCRIPTION
Not the most terribly useful addition, but this new setting allows the builder to set a specified debug level during core framework intialization.  The purpose of this is to quiet down the verbosity and server logs, but only until the framework has completed its initialization.  The setting then reverts back to the normal debug setting.