### PR TITLE
added option to run a pre-load script before framework initialization

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -185,6 +185,10 @@ const float ON_AREA_EMPTY_EVENT_DELAY = 180.0;
 //                                 Miscellaneous
 // -----------------------------------------------------------------------------
 
+// This is the script that will run before the framework initializes the first
+// time.  An empty string means no script will run.
+const string ON_MODULE_PRELOAD = "";
+
 // This is the welcome message that will be sent to all players and DMs that log
 // into the module.
 const string WELCOME_MESSAGE = "Welcome to the Core Framework.";

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -416,6 +416,8 @@ void InitializeCoreFramework()
 
     SetLocalInt(oModule, CORE_INITIALIZED, TRUE);
 
+    if (ON_MODULE_PRELOAD != "")
+        ExecuteScript(ON_MODULE_PRELOAD, GetModule());
     // Start debugging
     SetDebugLevel(DEFAULT_DEBUG_LEVEL, oModule);
     SetDebugLogging(DEBUG_LOGGING);


### PR DESCRIPTION
Generally this is not an issue in EE, however, in 1.69, initializatin the core-framework can cause TMI very quickly due to the modular nature of scripts and plugins that the framework allows.  This option was added in order to allow the build to run a specific script before the framework initialized.  Specifically, this was designed to allow NWNX2 users to raise thier TMI limit through nwnx_tmi before running into TMI during framework initilializtion, but it can be used for any functions the builder desires.