### PR TITLE
added tag-based scripting for all game objects

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -1150,11 +1150,9 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
     }
 
     // Run tag-based scripts for any object, items are already handled
-    if (oSelf != GetModule())
+    if (oSelf != GetModule() && GetObjectType(oSelf) != OBJECT_TYPE_ITEM)
     {
-        int nObjectType = GetObjectType(oSelf);
-        if (ENABLE_TAGBASED_SCRIPTS && !(nState & EVENT_STATE_ABORT) &&
-            nObjectType < OBJECT_TYPE_INVALID)
+        if (ENABLE_TAGBASED_SCRIPTS && !(nState & EVENT_STATE_ABORT) && GetIsObjectValid(oSelf))
             RunLibraryScript(GetTag(oSelf));
     }
     

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -1073,6 +1073,11 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
     // Initialize the script list for this event
     object oEvent = InitializeEvent(sEvent, oSelf, oInit);
 
+    // Tag-based scripting requires the current event be set, even if there are
+    // not scripts attached to the specified event.  This will be overwritten
+    // if there are scripts attached to this event.
+    SetLocalObject(EVENTS, EVENT_LAST, oEvent);
+
     // Ensure the blacklist is built
     if (!bLocalOnly)
         BuildPluginBlacklist(oSelf);
@@ -1144,6 +1149,15 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
             break;
     }
 
+    // Run tag-based scripts for any object, items are already handled
+    if (oSelf != GetModule())
+    {
+        int nObjectType = GetObjectType(oSelf);
+        if (ENABLE_TAGBASED_SCRIPTS && !(nState & EVENT_STATE_ABORT) &&
+            nObjectType < OBJECT_TYPE_INVALID)
+            RunLibraryScript(GetTag(oSelf));
+    }
+    
     // Clean up
     if (nEventLevel)
         OverrideDebugLevel(FALSE);


### PR DESCRIPTION
Added the option to have tag-based scripting for all game objects.  Currently, in the base game and in the framework, tag-based scripting is allowed for items only.  This addition allows for tag-based scripting for all game objects.  The library system is designed to reduce script count and consolidate like functions into single scripts.  This capability extended that idea.  It allows libraries such as this example, specified to areas, that allow builders to consolidate object-specific functions into libraries that otherwise would not have a good place to be included.  In this example, all local area-specific functions can be contained in a single library, which allow builders to easily find and change object-specific functions (vice setting variables) and consolidate excess scripts.  It also reduced the overall number of scripts (normal implementation) and number of registered library scripts (framework implementation).

This example library entry is not included in the PR, however, if desired, I have empty libraries for all game object types, with their events and available objects, just as the example below shows.
```c
void area_tag()
{
    string sEvent = GetName(GetCurrentEvent());
    object oPC, oArea = OBJECT_SELF;

    if (sEvent == AREA_EVENT_ON_ENTER)
    {
        oPC = GetEnteringObject();

    }
    else if (sEvent == AREA_EVENT_ON_EXIT)
    {
        oPC = GetExitingObject();

    }
    else if (sEvent == AREA_EVENT_ON_HEARTBEAT)
    {

    }
    else if (sEvent == AREA_EVENT_ON_USER_DEFINED)
    {
        int nEvent = GetUserDefinedEventNumber();

    }
    else if (sEvent == AREA_EVENT_ON_EMPTY)
    {

    }
}
```