### PR TITLE
Utility time

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -1,0 +1,165 @@
+# Core Utilities: Time
+
+*Disclaimer:  `util_i_time` will not function without other utility includes from squattingmonk's sm-utils.  Specifically, `util_i_debug`, `util_i_csvlists` and `util_i_math` are required.*
+
+NWN uses a hybrid time system which incorporates real-time minutes to advance the game clock at a specific rate.  This rate can be set in the module properties and determines how many real-world minutes will comprise one game-hour.  In order to properly maniupate time within a module, you must understand this time management ratio and use it to calculate time within the game.  There are no EE-specific functions in this include, so it should work with EE and 1.69 modules.
+
+`util_i_time` is a core framework utility include which provides time calculation, comparison and manipulation functions.
+
+## Terms and Concepts
+
+`System Time` - System time is the time NWN uses to track and manipulate time within the game.  System time is obtained with internal functions, such as `GetCalendarDay()` and `GetTimeSecond()` and is an unholy union of real time and accelerated game time.  An important feature of system time is that the minutes value can never be equal to or greater than the minute/game hour setting in the module's proprties.  With a default ratio of 2 minutes/game hour, the value retrieved from `GetTimeMinute()` will only ever be 0 or 1.
+
+`Game Time` - Game time represents the actual in-game time.  That is, if you were a character in your module, game time is the time would see on your clock/sundial.  Game Time is simply system time with the module's minutes/game hour setting taken into account to achieve a human-readable time.
+
+`Time Vector` - A time vector is a six-element comma-delimited list (`string`) representing, in order, years, months, days, hours, minutes and seconds.  Millisecond measurements are excluded from this include.  The format and order of these element are important for the proper functioning of this include, therefore, several functions have been created to help the user develop time vectors.  The values within a time vector represent an actual time.  For example, the system time vector `"1372, 6, 1, 4, 0, 15"` represents 4:0:15am, June 1, 1372.  The same system time vector represented as a game time vector would be `"1372, 6, 1, 4, 7, 30"`, which could represent 4:07:30am, June 1, 1372.
+
+*Note:  If you are creating a system time vector by hand, do not forget that the minutes element must be between 0 (inclusive) and the module's minutes/game hour setting (exclusive).*
+
+`Difference Vector` - A difference vector is a six-element comma-delimited list (`string`) representing, in order, years, months, days, hours, minutes, seconds.  Millisecond measurement are excluded from this include.  The format and order of these element are important for the proper functioning of this include, therefore, a function has been created to help the user develop time vectors.  The values within a difference vector represent changes to a specific time element.  Difference vectors are game time vectors.
+
+`Seconds Vector` - Unless you are a scripter, you will not use this concept.  For those digging into the code, seconds vectors are a two-element, comma-delimited list (`string`) represent, in order, years and seconds.  Seconds vectors are never created or directly manipuated by the user, but are used often in the code to transfer time values between functions without overloading the integer type or losing precision in a float type.
+
+`Vector Verification` - All time and difference vectors are verified before use.  If any vector element is less than 0 (or 1 depending on the application and vector type) will throw an error and return the string constant TIME_INVALID.  An explanation of how time elements that are greater than allowed is provided in the definition of `overloading` below.
+
+`Overloading` - Overloading applies to both time vectors and difference vectors.  If any element in a time or difference vector is greater than the normal unit value maximum (i.e. the hours element is > 23, of the minutes element > 59), the system will roll the extra time over to the next higher element.  As an example, if you create a difference element with the values `"0,0,0,168,0,0"` because you'd like to add 168 hours to a time, but don't want to figure out what that means in the various elements, you can `CreateDifferenceVector(0,0,0,168,0,0);` and the system will return the following vector `"0,0,7,0,0,0,0"` because 168 hours is the equivalent to seven days.
+
+`Pause` - It is important to note that these function respect the game's ability to pause time, if it does so.  For a single player module, the player can control pausing.  For persitent worlds, generally only DMs can pause the module.  If the module is paused, system and game time are paused.
+
+## Bioware Override Function
+
+`_SetCalendar()` is a custom function override for Bioware's `SetCalendar()` function.  `_SetCalendar()` will accept a system time vector in order to set NWN's game time.  This would be useful for moving the game's time forward by a set amount.  This function takes three paremeters:
+
+`sTime` - string, a system time vector.
+`nSetCalendar` - boolean, TRUE to set the system's calendar values.
+`nSetTime` - booelan, TRUE to set the system's time values.
+
+## Time Manipulation Functions
+
+Examples of function usage are shown in the Examples section.  Any function that takes a single time vector can be called without the time vector.  If no time vector is provided to the function, the system will get the current in-game time (GetSystemTime() or GetGameTime()) and use that value for any calculations.  Any function that accepts two time vectors can function with a single time vector provided.  The second time vector, if missing, will default to current time.
+
+`GetWeekDay()` - returns the day of the week of the passed date as an integer (1 - Monday, 7 - Sunday).
+
+`GetWeekDayName()` - returns the name of the weekday of the passed date.  You must either pass a comma-delimited string of weekday names or setup default weekday names to be referenced by the variable DAY_NAMES in `util_i_time`.
+
+`GetMonthName()` - returns the name of the month of the passed date.  You must either pass a comma-delimited string of month names or setup default month names to be referenced by the variable MONTH_NAMES in `util_i_time`.
+
+`_SetCalendar()` - see [Override Function](#override-function) above.
+
+`Get[System|Game]Time()` - will return the current in-game time as a time vector.
+
+`Get[Max|Min][System|Game]Time()` - takes two time vectors and determines which is the greatest, or least, and returns that time vector.
+
+`[Add|Subtract][System|Game]TimeElement()` - takes a TIME_* constant, value and time vector to perform the desired operation against the specified time element.
+
+`Get[System|Game]TimeDifference()` - returns a difference vector containing the difference between the two passed time vectors.
+
+`Create[System|Game]TimeVector()` - returns a time vector consisting of six passed time elements.
+
+`CreateDifferenceVector()` - returns a difference vector consisting of six passed time element differences.
+
+`Convert[System|Game]TimeTo[System|Game]Time()` - converts a time vector between the two time systems (system time and game time).
+
+`Convert[System|Game]TimeTo()` - returns a float representing the passed time vector in units equivalent to the passed time element.
+
+`ConvertDifferenceVectorTo()` - returns a float representing the passed difference vector in units equivalent to the passed time element.
+
+`Get[System|Game]TimeDifferenceIn()` - returns a float representing the difference bewteen two passed time vectors in units equivalent to the passed time element.
+
+`Format[System|Game]Time()` - returns a string with the passed time formatted in the passed date/time format.
+
+`GetPrecision[System|Game]Time()` - returns a time vector representing the passed time vector with passed precision.  This function serves to remove specific time elements from the time vector, starting with the seconds element.
+
+`GetFormattedTimeSinceEpoch()` - returns a formatted date/time group sourced from a UNIX timestamp.  This function will accept a UNIX timestamp such as that returned from `NWNX_Time_GetTimeStamp`.  *Warning: NWN uses 32-bit integers and the UNIX timestamp will eventually return errors due to type overflow (no worries, still 17 years to go!).*
+
+## Examples/Usage
+
+Following are several examples of how these functions can be used to manipulate time in your module.
+
+To obtain the current system or game time:
+``` cpp
+sSystem = GetSystemTime();
+sGame = GetGameTime();
+```
+
+To save the server's epoch (the time the server starts before being manipulated by any database variables or other functions), call this as soon as one of the first functions OnModuleLoad:
+``` cpp
+SetLocalString(GetModule(), "SERVER_EPOCH", GetSystemTime());
+```
+
+To add nHours hours to the current system time and set that time on the module:
+``` cpp
+void AdvanceTime(int nHours)
+{
+    string sNewTime = AddSystemTimeElement(TIME_HOURS, nHours, GetSystemTime());
+    _SetCalendar(sNewTime, TRUE, TRUE);
+}
+
+// or, with a difference vector...
+
+void AdvanceTime(nHours)
+{
+    string sDifference = CreateDifferenceVector(0,0,0,nHours,0,0);
+    string sNewTime = AddSystemTimeVector(GetSystemTime(), sDifference);
+    _SetCalendar(sNewTime, TRUE, TRUE);
+}
+```
+
+To see if a specified time period has passed since a specific event:
+``` cpp
+int CheckForMinRestTime(fMinHours)
+{
+    string sLastRestTime = GetLocalString(oPC, "LAST_REST_TIME");
+    if (GetSystemTimeDifferenceIn(TIME_HOURS, sLastRestTime)) >= fMinHours)
+        return TRUE;
+    else
+        return FALSE;
+}
+```
+
+To check is sTime1 is later than sTime2:
+``` cpp
+    if (GetMaxSystemTime(sTime1, sTime2) == sTime1)
+        // sTime1 is greater
+    else
+        // sTime2 is greater
+```
+
+To format a time vector with a specified format:
+``` cpp
+string GetFormattedCurrentTime()
+{
+    return FormatSystemTime("dddd, MMMM dd, yyyy, HH:mm:ss", GetSystemTime());
+}
+```
+
+To see if a specified time interval has passed from a previously saved time vector:
+``` cpp
+int HasTimePassed(int nDays)
+{
+    string sTime = GetLocalString(oPC, "EVENT_TIME");
+    sTime = AddSystemTimeElement(TIME_DAYS, nDays, sTime);
+    return (GetMaxSystemTime(sTime, GetSystemTime()) == sTime);
+}
+```
+
+## Notes
+* Most time functions have two complementary functions:  one for system time and one for game time.  The functions are generally identical, however, they will call different default times if an optional time vector is not passed.
+
+* FormatSystemTime() returns formatted game time using a system time input.  System time will not be formatted as system time does not represent an easy human-readable format because of the real minutes/game hour conversion.
+
+* Some calls are very instruction intensive.  It shouldn't be an issue in EE like it is in 1.69, but including functions such as Get[System|Game]TimeDifferenceIn() and Format[System|Game]Time() in a loop could cause TMI.
+
+* When calculating time differences, the times can be in any order ... the earlier time does not need to be passed first.  For example, with these two lines of code, sTime1 is server epoch and sTime2 is the current system time:
+        sTime1 = GetLocalString(GetModule(), "SERVER_EPOCH");
+        sTime2 = GetSystemTime();
+      
+    The following two calls will return the exact same result:
+        
+        sDifference = GetSystemTimeDifference(sTime1, sTime2);
+        sDifference = GetSystemTimeDifference(sTime2, sTime1);
+    If you are using current times, the same result can be achieved with the following, since current system time is assumed if sTime2 is not passed:
+
+        sDifference = GetSystemTimeDifference(sTime1);
+    
+* Most any function that requires only one time vector input will work without any time vector input.  Missing time vectors will default to using the current system/game time.  With functions that require two time vector inputs, the first is required and the second will revert to current time if not passed.

--- a/docs/time.md
+++ b/docs/time.md
@@ -66,7 +66,7 @@ Examples of function usage are shown in the Examples section.  Any function that
 
 `Get[System|Game]TimeDifferenceIn()` - returns a float representing the difference bewteen two passed time vectors in units equivalent to the passed time element.
 
-`Format[System|Game]Time()` - returns a string with the passed time formatted in the passed date/time format.
+`Format[System|Game]Time()` - returns a string with the passed time formatted in the passed date/time format.  If you are not using default weekday and month names, you can pass in a set of weekday and month names.  Weekday names must be a comma-delimited list of 7 words and months names must be a comma-delimited list of 12 words.
 
 `GetPrecision[System|Game]Time()` - returns a time vector representing the passed time vector with passed precision.  This function serves to remove specific time elements from the time vector, starting with the seconds element.
 

--- a/src/utils/util_i_time.nss
+++ b/src/utils/util_i_time.nss
@@ -1,0 +1,1212 @@
+// -----------------------------------------------------------------------------
+//    File: util_i_time.nss
+//  System: PW Administration
+// -----------------------------------------------------------------------------
+// Description:
+//  Time Management
+// -----------------------------------------------------------------------------
+// Builder Use:
+//  Modification of default format (DEFAULT_FORMAT) and elements names
+//  (DAY_NAMES & MONTH_NAMES).
+// -----------------------------------------------------------------------------
+
+#include "util_i_debug"
+#include "util_i_csvlists"
+#include "util_i_math"
+
+// -----------------------------------------------------------------------------
+//                              Constants
+// -----------------------------------------------------------------------------
+
+// This is the only constant you can/should change without affecting the system
+//  If you make a call to the formatting functions without specifying a format,
+//  this format will be used.
+const string DEFAULT_FORMAT = "dddd, MMMM d, yyyy, H:mm:ss";
+
+// Don't change anything below...
+const string TIME_INVALID = "TIME_INVALID";
+const string FORMAT_ELEMENTS = "y,M,d,~,m,s,h,H,t";
+const string ELEMENT_DEBUG = "TIME_YEARS, TIME_MONTHS, TIME_DAYS, TIME_HOURS, TIME_MINUTES, TIME_SECONDS";
+
+const int TIME_YEARS   = 0;
+const int TIME_MONTHS  = 1;
+const int TIME_DAYS    = 2;
+const int TIME_HOURS   = 3;
+const int TIME_MINUTES = 4;
+const int TIME_SECONDS = 5;
+
+const int SYSTEM_ELEMENTS  = 6;
+const int SECONDS_ELEMENTS = 2;
+
+const int MODE_SYSTEM = 0;
+const int MODE_GAME   = 1;
+
+const int VECTOR_DIFFERENCE = 0;
+const int VECTOR_TIME = 1;
+
+const int OPERATION_ADD      = 0;
+const int OPERATION_SUBTRACT = 1;
+
+const int RETURN_TIME    = 0;
+const int RETURN_SECONDS = 1;
+
+const int RETURN_MAX = 0;
+const int RETURN_MIN = 1;
+
+// Day and Month name constants can be added here.  There is no limit to the number
+//  of day and month name sets you can add.  Due to game mechanics, day names
+//  should be a comma-delmited list of seven names and month names should be a
+//  comma-delimited list of twelve names.  These constants can, and probably should,
+//  be defined elsewhere in the module but are included here to have default
+//  values available.
+const string ME_DAY_NAMES = "Moonday,Treeday,Heavensday,Valarday,Shipday,Starday,Sunday";
+const string ME_MONTH_NAMES = "Narvinye,Nenime,Sulime,V�resse,Lotesse,Narie,Cermie,Urime,Yavannie,Narquelie,Hisime,Ringare";
+const string US_DAY_NAMES = "Monday,Tuesday,Wednesday,Thursday,Friday,Saturday";
+const string US_MONTH_NAMES = "January,February,March,April,May,June,July,August,September,October,November,December";
+
+// For specific functions, if day and/or month names are not passed, these are
+//  the default values that will be used to determine day and month names.  This is
+//  a simple setup ... you can also use a custom function to determine which
+//  values are appropriate to use in your use case.
+string DAY_NAMES = US_DAY_NAMES;
+string MONTH_NAMES = US_MONTH_NAMES;
+
+// -----------------------------------------------------------------------------
+//                              Function Prototypes
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                             Calendar Functions
+// -----------------------------------------------------------------------------
+
+// ---< GetWeekDay >---
+// Given a calendar date (nDate), returns an integer representing the day of the
+//  week.  1 - Monday through 7 - Sunday.  If nDate is not passed, the current
+//  game date is used.
+int GetWeekDay(int nDate = 0);
+
+// ---< GetWeekDayName >---
+// Given an optional calendar day (nDate), returns a string with the name of the
+//  week day.  If nDate is not passed, the current game date is used.  If
+//  sDayNames is not passed, the default set in DAY_NAMES is used.
+string GetWeekDayName(int nDate = 0, string sDayNames = "");
+
+// ---< GetMonthName >---
+// Given an optional calendar month (nMonth), returns a string with the name of
+//  the month.  If nMonth is not passed, the current game month is used.  If
+//  sMonthNames is not passed, the default set in MONTH_NAMES is used.
+string GetMonthName(int nMonth = 0, string sMonthNames = "");
+
+// ---< _SetCalendar >---
+// Given a 6-element CSV system sTime, optionally set either or both the module's
+//  calendar and time.  This is a bioware function replacement that accepts CSV
+//  time strings, not a private function.
+void _SetCalendar(string sTime, int nSetCalendar = TRUE, int nSetTime = TRUE);
+
+// -----------------------------------------------------------------------------
+//                             Time Functions
+// -----------------------------------------------------------------------------
+
+// ---< GetSystemTime >---
+// Returns the system game time as a time vector.
+string GetSystemTime();
+
+// ---< GetGameTime >---
+// Returns the current game time as a time vector.
+string GetGameTime();
+
+// ---< GetMaxSystemTime >---
+// Returns the time vector that represents that compares system time vectors sTime1 and sTime2
+//  and returns the time vector which represents the greater time.  If sTime2 is not
+//  passed, current system time used.  Optionally, you can pass an element constant to use
+//  when comparing the two time vectors.  In some cases, changing nElement may increase the
+//  accuracy of the comparison, especially when comparing very small differences in time vectors.
+string GetMaxSystemTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS);
+
+// ---< GetMinSystemTime >---
+// Returns the time vector that represents that compares system time vectors sTime1 and sTime2
+//  and returns the time vector which represents the lesser time.  If sTime2 is not
+//  passed, current system time used.  Optionally, you can pass an element constant to use
+//  when comparing the two time vectors.  In some cases, changing nElement may increase the
+//  accuracy of the comparison, especially when comparing very small differences in time vectors.
+string GetMinSystemTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS);
+
+// ---< GetMaxGameTime >---
+// Returns the time vector that represents that compares system time vectors sTime1 and sTime2
+//  and returns the time vector which represents the greater time.  If sTime2 is not
+//  passed, current system time used.  Optionally, you can pass an element constant to use
+//  when comparing the two time vectors.  In some cases, changing nElement may increase the
+//  accuracy of the comparison, especially when comparing very small differences in time vectors.
+string GetMaxGameTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS);
+
+// ---< GetMinGameTime >---
+// Returns the time vector that represents that compares system time vectors sTime1 and sTime2
+//  and returns the time vector which represents the lesser time.  If sTime2 is not
+//  passed, current system time used.  Optionally, you can pass an element constant to use
+//  when comparing the two time vectors.  In some cases, changing nElement may increase the
+//  accuracy of the comparison, especially when comparing very small differences in time vectors.
+string GetMinGameTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS);
+
+// ---< AddSystemTimeElement >--
+// Returns a time vector with the specified nValue added to nElement.  If sTime is
+//  not passed, current system time is used.
+string AddSystemTimeElement(int nElement, int nValue, string sTime = TIME_INVALID);
+
+// ---< AddGameTimeElement >--
+// Returns a time vector with the specified nValue added to nElement.  If sTime is
+//  not passed, current game time is used.
+string AddGameTimeElement(int nElement, int nValue, string sTime = TIME_INVALID);
+
+// ---< AddSystemTimeVector >---
+// Returns a time vector with difference vector sDifference added to time vector sTime.
+string AddSystemTimeVector(string sTime, string sDifference);
+
+// ---< AddGameTimeVector >---
+// Returns a time vector with difference vector sDifference added to time vector sTime.
+string AddGameTimeVector(string sTime, string sDifference);
+
+// ---< SubtractSystemTimeElement >--
+// Returns a time vector with the specified nValue subtracted from nElement.  If sTime is
+//  not passed, current system time is used.
+string SubtractSystemTimeElement(int nElement, int nValue, string sTime = TIME_INVALID);
+
+// ---< SubtractGameTimeElement >--
+// Returns a time vector with the specified nValue subtracted from nElement.  If sTime is
+//  not passed, current game time is used.
+string SubtractGameTimeElement(int nElement, int nValue, string sTime = TIME_INVALID);
+
+// ---< SubtractSystemTimeVector >---
+// Returns a time vector with difference vector sDifference subtracted from time vector sTime.
+string SubtractSystemTimeVector(string sTime, string sDifference);
+
+// ---< SubtractGameTimeVector >---
+// Returns a time vector with difference vector sDifference subtracted from time vector sTime.
+string SubtractGameTimeVector(string sTime, string sDifference);
+
+// ---< GetSystemTimeDifference >---
+// Returns a time vector of the difference between time vectors sTime1 and sTime2.  If sTime2
+//  is not passed, current system time will be used.
+string GetSystemTimeDifference(string sTime1, string sTime2 = TIME_INVALID);
+
+// ---< GetGameTimeDifference >---
+// Returns a time vector of the difference between time vectors sTime1 and sTime2.  If sTime2
+//  is not passed, current game time will be used.
+string GetGameTimeDifference(string sTime1, string sTime2 = TIME_INVALID);
+
+// ---< CreateSystemTimeVector >---
+// Returns a system time vector with specified elements.
+string CreateSystemTimeVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1);
+
+// ---< CreateGameTimeVector >---
+// Returns a game time vector with specified elements.
+string CreateGameTimeVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1);
+
+// ---< CreateDifferenceVector >---
+// Returns a difference vector with specified elements.
+string CreateDifferenceVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1);
+
+// ---< ConvertGameTimeToSystemTime >---
+// Converts a game time vector to a system time vector.
+string ConvertGameTimeToSystemTime(string sTime = TIME_INVALID);
+
+// ---< ConvertSystemTimeToGameTime >---
+// Converts a system time vector to a game time vector.
+string ConvertSystemTimeToGameTime(string sTime = TIME_INVALID);
+
+// ---< ConvertSystemTimeTo >---
+// Converts a system time vector into nElement units.  nElement is a TIME_* constant.  If
+//  sTime is not passed, current system time will be used.
+float ConvertSystemTimeTo(int nElement, string sTime = TIME_INVALID);
+
+// ---< ConvertGameTimeTo >---
+// Converts a game time vector into nElement units.  nElement is a TIME_* constant.  If
+//  sTime is not passed, current game time will be used.
+float ConvertGameTimeTo(int nElement, string sTime = TIME_INVALID);
+
+// ---< ConvertDifferenceVectorTo >---
+// Converts a difference vector to nElement units.  nElement is a TIME_* constant.  If
+//  sTime is not passed, current game time will be used.
+float ConvertDifferenceVectorTo(int nElement, string sTime = TIME_INVALID);
+
+// ---< GetSystemTimeDifferenceIn >---
+// Finds the difference between two system time vectors and returns the result in nElement
+//  units.  nElement is a TIME_* constant.  If sTime2 is not passed, currnet system time will be used.
+float GetSystemTimeDifferenceIn(int nElement, string sTime1, string sTime2 = TIME_INVALID);
+
+// ---< GetGameTimeDifferenceIn >---
+// Finds the difference between two game time vectors and returns the result in nElement
+//  units.  nElement is a TIME_* constant.  If sTime2 is not passed, currnet game time will be used.
+float GetGameTimeDifferenceIn(int nElement, string sTime1, string sTime2 = TIME_INVALID);
+
+// ---< FormatSystemTime >---
+// Formats a system time vector as the specified sFormat.  If sTime is not passed, current system
+//  time will be used.  If sFormat is not passed, the DEFAULT_FORMAT constant will be used.
+string FormatSystemTime(string sFormat = DEFAULT_FORMAT, string sTime = TIME_INVALID);
+
+// ---< FormatGameTime >---
+// Formats a game time vector as the specified sFormat.  If sTime is not passed, current game
+//  time will be used.  If sFormat is not passed, the DEFAULT_FORMAT constant will be used.
+string FormatGameTime(string sFormat = DEFAULT_FORMAT, string sTime = TIME_INVALID);
+
+// ---< GetPrecisionSystemTime >---
+// Returns a six-element comma-delimited string containing time elements from sTime up to
+//  nPrecision elements.  If sTime is not passed, current system time is used.
+string GetPrecisionSystemTime(int nPrecision = TIME_SECONDS, string sTime = TIME_INVALID);
+
+// ---< GetPrecisionGameTime >---
+// Returns a six-element comma-delimited string containing time elements from sTime up to
+//  nPrecision elements.  If sTime is not passed, current game time is used.
+string GetPrecisionGameTime(int nPrecision = TIME_SECONDS, string sTime = TIME_INVALID);
+
+// ---< GetFormattedTimeSinceEpoch >---
+// Accepts UNIX timestampt nSeconds and returns a formatted date/time based on sFormat.
+string GetFormattedTimeSinceEpoch(int nSeconds, string sFormat = DEFAULT_FORMAT);
+
+// Private function, prototyped for use in calendar functions.
+string _ValidateTime(string sTime, int nMode = MODE_SYSTEM, int nVector = VECTOR_TIME);
+
+// -----------------------------------------------------------------------------
+//                             Function Definitions
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                             Calendar Functions
+// -----------------------------------------------------------------------------
+
+int GetWeekDay(int nDate = 0)
+{
+    if (nDate <= 0)
+        nDate = GetCalendarDay();
+    else if (nDate > 28)
+        nDate %= 28;
+    
+    int nDay = nDate % 7;
+
+    return (nDay ? nDay : 7);
+}
+
+string GetWeekDayName(int nDate = 0, string sDayNames = "")
+{
+    if (nDate <= 0)
+        nDate = GetCalendarDay();
+    else if (nDate > 28)
+        nDate %= 28;
+
+    if (sDayNames == "")
+        sDayNames = DAY_NAMES;
+
+    nDate = GetWeekDay(nDate);
+    return GetListItem(sDayNames, nDate - 1);
+}
+
+string GetMonthName(int nMonth = 0, string sMonthNames = "")
+{
+    if (nMonth <= 0 || nMonth > 12)
+        nMonth = GetCalendarMonth();
+
+    if (sMonthNames == "")
+        sMonthNames = MONTH_NAMES;
+
+    return GetListItem(sMonthNames, nMonth - 1);
+}
+
+void _SetCalendar(string sTime, int nSetCalendar = TRUE, int nSetTime = TRUE)
+{    
+    string error, debug = "_SetCalendar :: ";
+
+    if ((sTime = _ValidateTime(sTime)) == TIME_INVALID)
+        return;
+    
+    if (CountList(sTime) != SYSTEM_ELEMENTS)
+        error = AddListItem(error, "Passed sTime did not contain the correct number of time elements.");
+
+    if (!nSetCalendar && !nSetTime)
+        error = AddListItem(error, "Procedure called with both nSetCalendar and nSetTime passed as FALSE.");
+
+    if (CountList(error))
+    {
+        Error(debug + error +
+                    "\n   sTime        = " + sTime +
+                    "\n   nSetCalendar = " + (nSetCalendar ? "TRUE" : "FALSE") +
+                    "\n   nSetTime     = " + (nSetTime ? "TRUE" : "FALSE"));
+        return;
+    }
+
+    if (nSetCalendar)
+    {
+        int nYear   = StringToInt(GetListItem(sTime, 0));
+        int nMonth  = StringToInt(GetListItem(sTime, 1));
+        int nDay    = StringToInt(GetListItem(sTime, 2));
+        SetCalendar(nYear, nMonth, nDay);
+    }
+
+    if (nSetTime)
+    {
+        int nHour   = StringToInt(GetListItem(sTime, 3));
+        int nMinute = StringToInt(GetListItem(sTime, 4));
+        int nSecond = StringToInt(GetListItem(sTime, 5));
+        SetTime(nHour, nMinute, nSecond, 0);
+    }
+}
+
+// -----------------------------------------------------------------------------
+//                             Time Functions
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//                             Private Functions
+// -----------------------------------------------------------------------------
+
+// Internal Function.  Validates a 6-element CSV containing time elements to ensure all elements
+//  are within normal time limits.  Errors on the low-side will result in TIME_INVALID, errors
+//  on the high-side will add the appropriate time to the next higher-order time element.  nMode
+//  determines whether game time or system time is being validated.  If validating difference
+//  vectors, nVector is used to make a range correction.
+string _ValidateTime(string sTime, int nMode = MODE_SYSTEM, int nVector = VECTOR_TIME)
+{
+    string elements, debug = "_ValidateTime :: ";
+
+    if (CountList(sTime) != SYSTEM_ELEMENTS)
+    {
+        Error(debug + "Passed sTime did not contain the correct number of time elements." +
+                    "\n   sTime   = " + sTime +
+                    "\n   nMode   = " + (nMode == MODE_SYSTEM ? "MODE_SYSTEM" : "MODE_GAME") +
+                    "\n   nVector = " + (nVector == VECTOR_TIME ? "VECTOR_TIME" : "VECTOR_DIFFERENCE"));
+        return TIME_INVALID;
+    }
+
+    int nYear, nMonth, nDay, nHour, nMinute, nSecond, nMinutesPerHour;
+
+    nYear   = StringToInt(GetListItem(sTime, 0));
+    nMonth  = StringToInt(GetListItem(sTime, 1));
+    nDay    = StringToInt(GetListItem(sTime, 2));
+    nHour   = StringToInt(GetListItem(sTime, 3));
+    nMinute = StringToInt(GetListItem(sTime, 4));
+    nSecond = StringToInt(GetListItem(sTime, 5));
+
+    if (nMode == MODE_SYSTEM)
+        nMinutesPerHour = FloatToInt(HoursToSeconds(1) / 60);
+    else
+        nMinutesPerHour = 60;
+
+    if (nSecond < 0)
+        elements = AddListItem(elements, "seconds");
+    else if (nSecond > 60)
+    {
+        nMinute += (nSecond / 60);
+        nSecond %= 60;
+    }
+
+    if (nMinute < 0)
+        elements = AddListItem(elements, "minutes");
+    else if (nMinute > (nMinutesPerHour - 1))
+    {
+        nHour += (nMinute / nMinutesPerHour);
+        nMinute %= nMinutesPerHour;
+    }
+
+    if (nHour < 0)
+        elements = AddListItem(elements, "hours");
+    else if (nHour > 24)
+    {
+        nDay += (nHour / 24);
+        nHour %= 24;
+    }    
+
+    if (nDay < (0 + nVector))
+        elements = AddListItem(elements, "days");
+    else if (nDay > 28)
+    {
+        nMonth += (nDay / 28);
+        nDay %= 28;
+    }
+
+    if (nMonth < (0 + nVector))
+        elements = AddListItem(elements, "months");
+    else if (nMonth > 12)
+    {
+        nYear += (nMonth / 12);
+        nMonth %= 12;
+    }
+
+    if (nYear < 0 || nYear > 32001)
+        elements = AddListItem(elements, "years");
+
+    if (CountList(elements))
+    {
+        Error(debug + "The following time elements were out of range: " + elements +
+                    "\n   sTime = " + sTime +
+                    "\n   nMode = " + (nMode == MODE_SYSTEM ? "MODE_SYSTEM" : "MODE_GAME"));
+        return TIME_INVALID;
+    }
+
+    sTime = "";
+    sTime = AddListItem(sTime, IntToString(nYear));
+    sTime = AddListItem(sTime, IntToString(nMonth));
+    sTime = AddListItem(sTime, IntToString(nDay));
+    sTime = AddListItem(sTime, IntToString(nHour));
+    sTime = AddListItem(sTime, IntToString(nMinute));
+    return  AddListItem(sTime, IntToString(nSecond));
+}
+
+float _GetConversionFactor(int nFrom, int nTo)
+{
+    if (nFrom == nTo)
+        return 1.0;
+
+    string sFactors = "12,28,24,60,60,1";
+
+    if (nFrom > nTo)
+        return (1.0 / _GetConversionFactor(nTo, nFrom));
+
+    int i, nFactor = 1;
+    for (i = nFrom; i < nTo; i++)
+        nFactor *= StringToInt(GetListItem(sFactors, i));
+
+    return IntToFloat(nFactor);
+}
+
+// Internal function.  Returns either system time or game time as a six-element
+//  comma-delimited string.
+string _CreateTimeVector(int nMode, int nVector, int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1)
+{
+    if (nYear   == -1) nYear   = GetCalendarYear();
+    if (nMonth  == -1) nMonth  = GetCalendarMonth();
+    if (nDay    == -1) nDay    = GetCalendarDay();
+    if (nHour   == -1) nHour   = GetTimeHour();
+    if (nMinute == -1) nMinute = GetTimeMinute();
+    if (nSecond == -1) nSecond = GetTimeSecond();
+
+    string sTime;
+    sTime = AddListItem(sTime, IntToString(nYear));
+    sTime = AddListItem(sTime, IntToString(nMonth));
+    sTime = AddListItem(sTime, IntToString(nDay));
+    sTime = AddListItem(sTime, IntToString(nHour));
+    sTime = AddListItem(sTime, IntToString(nMinute));
+    sTime = AddListItem(sTime, IntToString(nSecond));
+    
+    if ((sTime = _ValidateTime(sTime, nMode, nVector)) == TIME_INVALID)
+        return TIME_INVALID;
+
+    if (nMode == MODE_GAME)
+        sTime = ConvertSystemTimeToGameTime(sTime);    
+
+    return sTime;
+}
+
+// Internal function.  Converts seconds vectors to specified time elements.  Can
+// lose precision with large numbers, so should only be used for short timespans.
+float _ConvertSecondsVectorTo(int nElement, string sTime, int nMode = MODE_GAME)
+{                                                     
+    int nYear = StringToInt(GetListItem(sTime, 0));
+    int nSecond = StringToInt(GetListItem(sTime, 1));
+
+    float fYear = nYear * _GetConversionFactor(TIME_YEARS, nElement);
+    float fSecond = nSecond * _GetConversionFactor(TIME_SECONDS, nElement);
+    
+    float fTotal = fYear + fSecond;
+    if (nMode == MODE_SYSTEM)
+    {
+        fTotal *= _GetConversionFactor(nElement, TIME_SECONDS);
+        fTotal /= 3600/(HoursToSeconds(1));
+        fTotal *= _GetConversionFactor(TIME_SECONDS, nElement);
+    }
+
+    return fTotal;
+}
+
+// Internal function.  Converts game time into (years, seconds).
+string _ConvertGameTimeToSecondsVector(string sTime, int nVector = VECTOR_TIME)
+{
+    int nYear, nMonth, nDay, nHour, nMinute, nSecond;
+
+    nYear   = StringToInt(GetListItem(sTime, 0));
+    nMonth  = StringToInt(GetListItem(sTime, 1));
+    nDay    = StringToInt(GetListItem(sTime, 2));
+    nHour   = StringToInt(GetListItem(sTime, 3));
+    nMinute = StringToInt(GetListItem(sTime, 4));
+    nSecond = StringToInt(GetListItem(sTime, 5));
+
+    nSecond = (nVector == VECTOR_DIFFERENCE ? nMonth : max(nMonth - 1, 0)) * FloatToInt(_GetConversionFactor(TIME_MONTHS,  TIME_SECONDS)) +
+              (nVector == VECTOR_DIFFERENCE ? nDay   : max(nDay   - 1, 0)) * FloatToInt(_GetConversionFactor(TIME_DAYS,    TIME_SECONDS)) +
+               nHour                                               * FloatToInt(_GetConversionFactor(TIME_HOURS,   TIME_SECONDS)) +
+               nMinute                                             * FloatToInt(_GetConversionFactor(TIME_MINUTES, TIME_SECONDS)) +
+               nSecond;
+
+    sTime = "";
+    sTime = AddListItem(sTime, IntToString(nYear));
+    return  AddListItem(sTime, IntToString(nSecond));
+}
+
+// Internal function.  Converts seconds vector to game time.
+string _ConvertSecondsVectorToGameTime(string sTime, int nVector = VECTOR_DIFFERENCE)
+{
+    int nMonth, nDay, nHour, nMinute;
+    int nYear = StringToInt(GetListItem(sTime, 0));
+    int nSecond = StringToInt(GetListItem(sTime, 1));
+
+    int nPerMonth  = FloatToInt(_GetConversionFactor(TIME_MONTHS,  TIME_SECONDS));
+    int nPerDay    = FloatToInt(_GetConversionFactor(TIME_DAYS,    TIME_SECONDS));
+    int nPerHour   = FloatToInt(_GetConversionFactor(TIME_HOURS,   TIME_SECONDS));
+    int nPerMinute = FloatToInt(_GetConversionFactor(TIME_MINUTES, TIME_SECONDS));
+
+    nMonth = (nSecond / nPerMonth) + nVector;
+    nSecond -= (nMonth - nVector) * nPerMonth;
+
+    nDay = (nSecond / nPerDay) + nVector;
+    nSecond -= (nDay - nVector) * nPerDay;
+
+    nHour = nSecond / nPerHour;
+    nSecond -= nHour * nPerHour;
+
+    nMinute = nSecond / nPerMinute;
+    nSecond -= nMinute * nPerMinute;
+
+    string sTime;
+    sTime = AddListItem(sTime, IntToString(nYear));
+    sTime = AddListItem(sTime, IntToString(nMonth));
+    sTime = AddListItem(sTime, IntToString(nDay));
+    sTime = AddListItem(sTime, IntToString(nHour));
+    sTime = AddListItem(sTime, IntToString(nMinute));
+    return sTime = AddListItem(sTime, IntToString(nSecond));
+}
+
+// Finds the difference between two six-element game-time strings
+string _GetGameTimeDifference(string sTime1, string sTime2, int nReturn)
+{
+    int nYears, nSeconds;
+
+    string sSeconds1 = _ConvertGameTimeToSecondsVector(sTime1, VECTOR_TIME);
+    string sSeconds2 = _ConvertGameTimeToSecondsVector(sTime2, VECTOR_TIME);
+
+    int nYear1 = StringToInt(GetListItem(sSeconds1, 0));
+    int nYear2 = StringToInt(GetListItem(sSeconds2, 0));
+
+    int nSeconds1 = StringToInt(GetListItem(sSeconds1, 1));
+    int nSeconds2 = StringToInt(GetListItem(sSeconds2, 1));
+
+    if (nYear1 > nYear2)
+        return _GetGameTimeDifference(sTime2, sTime1, nReturn);
+
+    if (nYear1 != nYear2)
+    {
+        int nPerYear = FloatToInt(_GetConversionFactor(TIME_YEARS, TIME_SECONDS));
+        nSeconds = ((nPerYear - nSeconds1) + nSeconds2) % nPerYear;
+        nYears = nYear2 - nYear1 + (nSeconds1 > nSeconds2 ? -1 : 0);
+    }
+    else
+    {
+        nSeconds = abs(nSeconds2 - nSeconds1);
+        nYears = 0;
+    }
+
+    string sTime;
+    sTime = AddListItem(sTime, IntToString(nYears));
+    sTime = AddListItem(sTime, IntToString(nSeconds));
+
+    if (nReturn == RETURN_SECONDS)
+        return sTime;
+    else
+        return _ConvertSecondsVectorToGameTime(sTime, VECTOR_DIFFERENCE);
+}
+
+// Internal function.  Finds the difference between two times.
+string _GetTimeDifference(string sTime1, string sTime2, int nMode, int nReturn)
+{
+    if ((sTime1 = _ValidateTime(sTime1, nMode)) == TIME_INVALID)
+        return TIME_INVALID;
+
+    if (sTime2 == TIME_INVALID || sTime2 == "")
+        sTime2 = (nMode == MODE_GAME ? GetGameTime() : GetSystemTime());
+    else if ((sTime2 = _ValidateTime(sTime2, nMode)) == TIME_INVALID)
+        return TIME_INVALID;
+
+    if (nMode == MODE_SYSTEM)
+    {
+        sTime1 = ConvertSystemTimeToGameTime(sTime1);
+        sTime2 = ConvertSystemTimeToGameTime(sTime2);
+        return _GetGameTimeDifference(sTime1, sTime2, nReturn);
+    }
+    else
+        return _GetGameTimeDifference(sTime1, sTime2, nReturn);
+}
+
+// Interal function.  Formats a specified elements based on desired formatting.
+string _FormatTimeElement(string sElement, string sFormat)
+{
+    string s = GetStringLeft(sFormat, 1);
+    int nLen = GetStringLength(sFormat);
+    int nElement = StringToInt(sElement);
+
+    if (s == "d" || s == "M")
+    {
+        switch (nLen)
+        {
+            case 1: break;
+            case 2:  
+                if (nElement < 10) 
+                    sElement = "0" + sElement;
+
+                break;
+            case 3:
+                sElement = (s == "d" ? GetWeekDayName(nElement) : GetMonthName(nElement));
+                sElement = GetStringLeft(sElement, 3);
+                break;
+            case 4:
+                sElement = (s == "d" ? GetWeekDayName(nElement) : GetMonthName(nElement));
+                break;
+        }
+    }
+    else if (s == "h" || s == "H" || s == "m" || s == "s")
+    {
+        if (s == "h")
+        {
+            nElement = nElement > 12 ? nElement - 12 : nElement;
+            sElement = IntToString(nElement);
+        }
+
+        switch (nLen)
+        {
+            case 1: break;
+            case 2:
+                if (nElement < 10)
+                {
+                    sElement = "0" + sElement;
+                    break;
+                }
+        }
+    }
+    else if (s == "y")
+    {
+        switch (nLen)
+        {
+            case 1:
+                if (GetStringLength(sElement) > 2)
+                    sElement = GetStringRight(sElement, 2);
+                break;                
+            case 2:
+                if (GetStringLength(sElement) > 2)
+                    sElement = "0" + GetStringRight(sElement, 2);
+            case 3:
+            case 4:
+                break;
+        }
+    }
+    else if (s == "t")
+    {
+        switch (nLen)
+        {
+            case 1:
+                sElement = nElement < 12 ? "A" : "P";
+                break;
+            case 2:
+                sElement = nElement < 12 ? "AM" : "PM";
+                break;
+        }
+    }
+
+    return sElement;
+}
+
+// Internal function.  Modifies sTime with sDifference
+string _ModifyTime(string sTime, string sDifference, int nMode = MODE_SYSTEM, int nOperation = OPERATION_ADD)
+{
+    string elements, debug = "_ModifyTime :: ";
+
+    if (sTime == TIME_INVALID)
+        sTime = (nMode == MODE_SYSTEM ? GetSystemTime() : GetGameTime());
+    else if (CountList(sTime) != SYSTEM_ELEMENTS)
+        elements = AddListItem(elements, "sTime");
+
+    if ((sTime = _ValidateTime(sTime, nMode)) == TIME_INVALID)
+        elements = AddListItem(elements, "sTime", TRUE);
+        
+    if (sDifference == TIME_INVALID || CountList(sDifference) != SYSTEM_ELEMENTS)
+        elements = AddListItem(elements, "sDifference");
+
+    if ((sDifference = _ValidateTime(sDifference, nMode, VECTOR_DIFFERENCE)) == TIME_INVALID)
+        elements = AddListItem(elements, "sDifference", TRUE);
+
+    if (CountList(elements))
+    {
+        if (IsDebugging(DEBUG_LEVEL_ERROR))
+            Error(debug + "The following arguments are either invalid or do not contain the required " +
+                    "number of time elements:  " + elements +
+                    "\n   sTime       = " + sTime +
+                    "\n   sDifference = " + sDifference +
+                    "\n   nMode       = " + (nMode == MODE_SYSTEM ? "MODE_SYSTEM" : "MODE_GAME") +
+                    "\n   nOperation  = " + (nOperation == OPERATION_ADD ? "ADDITION" : "SUBTRACTION"));
+        return TIME_INVALID;
+    }
+
+    int nYears, nYear1, nYear2, nSeconds, nSecond1, nSecond2, nPerYear = FloatToInt(_GetConversionFactor(TIME_YEARS, TIME_SECONDS));
+
+    if (nMode == MODE_SYSTEM)
+    {
+        sTime = ConvertSystemTimeToGameTime(sTime);
+        sDifference = ConvertSystemTimeToGameTime(sDifference);
+    }
+
+    sTime = _ConvertGameTimeToSecondsVector(sTime, VECTOR_TIME);
+    sDifference = _ConvertGameTimeToSecondsVector(sDifference, VECTOR_DIFFERENCE);
+
+    nYear1 = StringToInt(GetListItem(sTime, 0));
+    nSecond1 = StringToInt(GetListItem(sTime, 1));
+    
+    nYear2 = StringToInt(GetListItem(sDifference, 0));
+    nSecond2 = StringToInt(GetListItem(sDifference, 1));
+
+    nSeconds = nSecond1 + (nOperation == OPERATION_ADD ? nSecond2 : nSecond2 * -1);
+    nYears = nYear1 + (nOperation == OPERATION_ADD ? nYear2 : nYear2 * -1);
+
+    if (nSeconds >= nPerYear)
+    {
+        nYears = nYears + (nSeconds / nPerYear);
+        nSeconds = nSeconds % nPerYear;        
+    }
+    else if (nSeconds < 0)
+    {
+        nYears = nYears - (nSeconds / nPerYear) - 1;
+        nSeconds = nPerYear - abs(nSeconds);
+    }
+
+    sTime = "";
+    sTime = AddListItem(sTime, IntToString(nYears));
+    sTime = AddListItem(sTime, IntToString(nSeconds));
+    sTime = _ConvertSecondsVectorToGameTime(sTime, VECTOR_TIME);
+
+    return (nMode == MODE_SYSTEM ? ConvertGameTimeToSystemTime(sTime) : sTime);
+}
+
+string _ModifyTimeElement(int nElement, int nValue, string sTime, int nMode, int nOperation)
+{
+    if (!nValue)
+        return sTime;
+
+    if (nValue < 0 && nOperation == OPERATION_ADD)
+        nOperation = OPERATION_SUBTRACT;
+ 
+    nValue = abs(nValue);
+
+    string sDifference = CreateDifferenceVector(nElement == TIME_YEARS   ? nValue : 0,
+                                                nElement == TIME_MONTHS  ? nValue : 0,
+                                                nElement == TIME_DAYS    ? nValue : 0,
+                                                nElement == TIME_HOURS   ? nValue : 0,
+                                                nElement == TIME_MINUTES ? nValue : 0,
+                                                nElement == TIME_SECONDS ? nValue : 0);
+    return _ModifyTime(sTime, sDifference, nMode, nOperation);
+}
+
+string _CompareTimeVectors(string sTime1, string sTime2, int nElement, int nMode, int nCompare)
+{
+    if (sTime1 == sTime2)
+        return sTime1;
+
+    if (sTime2 == TIME_INVALID)
+        sTime2 = (nMode == MODE_SYSTEM ? GetSystemTime() : GetGameTime());
+    else if ((sTime2 = _ValidateTime(sTime2, nMode, VECTOR_TIME)) == TIME_INVALID)
+        return TIME_INVALID;
+    
+    if ((sTime1 = _ValidateTime(sTime1, nMode, VECTOR_TIME)) == TIME_INVALID)
+        return TIME_INVALID;
+
+    float fTime1 = (nMode == MODE_SYSTEM ? ConvertSystemTimeTo(nElement, sTime1) : ConvertGameTimeTo(nElement, sTime2));
+    float fTime2 = (nMode == MODE_SYSTEM ? ConvertSystemTimeTo(nElement, sTime2) : ConvertGameTimeTo(nElement, sTime2));
+
+    if (fTime1 > fTime2)
+        return (nCompare == RETURN_MAX ? sTime1 : sTime2);
+    else
+        return (nCompare == RETURN_MAX ? sTime2 : sTime1);
+}
+
+string _GetPrecisionTime(string sTime = TIME_INVALID, int nPrecision = TIME_SECONDS)
+{
+    string debug = "GetPrecisionSystemTime :: ";
+
+    nPrecision = clamp(nPrecision, TIME_YEARS, TIME_SECONDS);
+    int nYear, nMonth, nDay, nHour, nMinute, nSecond;
+    
+    if (CountList(sTime) == SYSTEM_ELEMENTS)
+    {
+        nYear   = StringToInt(GetListItem(sTime, 0));
+        nMonth  = StringToInt(GetListItem(sTime, 1));
+        nDay    = StringToInt(GetListItem(sTime, 2));
+        nHour   = StringToInt(GetListItem(sTime, 3));
+        nMinute = StringToInt(GetListItem(sTime, 4));
+        nSecond = StringToInt(GetListItem(sTime, 5));
+    }
+    else
+    {
+        Error(debug + "The passed time argument did not contain the correct number " +
+                " of time elements." +
+                "\n   sTime      = " + sTime +
+                "\n   nPrecision = " + GetListItem(ELEMENT_DEBUG, nPrecision));
+        return TIME_INVALID;
+    }
+
+    string sTime;
+    sTime = AddListItem(sTime, IntToString(nYear));
+    sTime = AddListItem(sTime, IntToString(nPrecision >= TIME_MONTHS  ? nMonth  : 1));
+    sTime = AddListItem(sTime, IntToString(nPrecision >= TIME_DAYS    ? nDay    : 1));
+    sTime = AddListItem(sTime, IntToString(nPrecision >= TIME_HOURS   ? nHour   : 0));
+    sTime = AddListItem(sTime, IntToString(nPrecision >= TIME_MINUTES ? nMinute : 0));
+    sTime = AddListItem(sTime, IntToString(nPrecision >= TIME_SECONDS ? nSecond : 0));
+    return _ValidateTime(sTime, MODE_SYSTEM);
+}
+
+// -----------------------------------------------------------------------------
+//                             Public Functions
+// -----------------------------------------------------------------------------
+
+string GetSystemTime()
+{
+    return GetPrecisionSystemTime();
+}
+
+string GetGameTime()
+{
+    return ConvertSystemTimeToGameTime(GetSystemTime());
+}
+
+string GetMaxSystemTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS)
+{
+    return _CompareTimeVectors(sTime1, sTime2, nElement, MODE_SYSTEM, RETURN_MAX);
+}
+
+string GetMinSystemTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS)
+{
+    return _CompareTimeVectors(sTime1, sTime2, nElement, MODE_SYSTEM, RETURN_MIN);
+}
+
+string GetMaxGameTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS)
+{
+    return _CompareTimeVectors(sTime1, sTime2, nElement, MODE_GAME, RETURN_MAX);
+}
+
+string GetMinGameTime(string sTime1, string sTime2 = TIME_INVALID, int nElement = TIME_HOURS)
+{
+    return _CompareTimeVectors(sTime1, sTime2, nElement, MODE_GAME, RETURN_MIN);
+}
+
+string AddSystemTimeElement(int nElement, int nValue, string sTime = TIME_INVALID)
+{
+    return _ModifyTimeElement(nElement, nValue, sTime, MODE_SYSTEM, OPERATION_ADD);
+}
+
+string AddGameTimeElement(int nElement, int nValue, string sTime = TIME_INVALID)
+{
+    return _ModifyTimeElement(nElement, nValue, sTime, MODE_GAME, OPERATION_ADD);
+}
+
+string AddSystemTimeVector(string sTime, string sDifference)
+{
+    return _ModifyTime(sTime, sDifference, MODE_SYSTEM, OPERATION_ADD);    
+}
+
+string AddGameTimeVector(string sTime, string sDifference)
+{
+    return _ModifyTime(sTime, sDifference, MODE_GAME, OPERATION_ADD);
+}
+
+string SubtractSystemTimeElement(int nElement, int nValue, string sTime = TIME_INVALID)
+{
+    return _ModifyTimeElement(nElement, nValue, sTime, MODE_SYSTEM, OPERATION_SUBTRACT);
+}
+
+string SubtractGameTimeElement(int nElement, int nValue, string sTime = TIME_INVALID)
+{
+    return _ModifyTimeElement(nElement, nValue, sTime, MODE_GAME, OPERATION_SUBTRACT);
+}
+
+string SubtractSystemTimeVector(string sTime, string sDifference)
+{
+    return _ModifyTime(sTime, sDifference, MODE_SYSTEM, OPERATION_SUBTRACT);
+}
+
+string SubtractGameTimeVector(string sTime, string sDifference)
+{
+    return _ModifyTime(sTime, sDifference, MODE_GAME, OPERATION_SUBTRACT);
+}
+
+string GetSystemTimeDifference(string sTime1, string sTime2 = TIME_INVALID)
+{
+    return ConvertGameTimeToSystemTime(_GetTimeDifference(sTime1, sTime2, MODE_SYSTEM, RETURN_TIME));
+}
+
+string GetGameTimeDifference(string sTime1, string sTime2 = TIME_INVALID)
+{
+    return _GetTimeDifference(sTime1, sTime2, MODE_GAME, RETURN_TIME);
+}
+
+string CreateSystemTimeVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1)
+{
+    return _CreateTimeVector(MODE_SYSTEM, VECTOR_TIME, nYear, nMonth, nDay, nHour, nMinute, nSecond);
+}
+
+string CreateGameTimeVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1)
+{
+    return _CreateTimeVector(MODE_GAME, VECTOR_TIME, nYear, nMonth, nDay, nHour, nMinute, nSecond);
+}
+
+string CreateDifferenceVector(int nYear = -1, int nMonth = -1, int nDay = -1, int nHour = -1, int nMinute = -1, int nSecond = -1)
+{
+    return _CreateTimeVector(MODE_GAME, VECTOR_DIFFERENCE, nYear, nMonth, nDay, nHour, nMinute, nSecond);
+}
+
+string ConvertGameTimeToSystemTime(string sTime = TIME_INVALID)
+{
+    string debug = "ConvertGameTimeToSystemTime :: ";
+
+    if (sTime == TIME_INVALID)
+        sTime = GetGameTime();
+    else if (CountList(sTime) != SYSTEM_ELEMENTS)
+    {
+        Error(debug + "The passed time argument did not contain the correct number " +
+                " of time elements." +
+                "\n   sTime = " + sTime);
+        return TIME_INVALID;
+    }
+
+    int nMinute, nSecond;
+    float fMinute, fSecond;
+
+    nMinute = StringToInt(GetListItem(sTime, 4));
+    nSecond = StringToInt(GetListItem(sTime, 5));
+
+
+
+    float fDecimalSecond = nSecond / 60.0;
+    float fDecimalMinute = (IntToFloat(nMinute) + fDecimalSecond);
+    fMinute = fDecimalMinute * (HoursToSeconds(1) / 60.0);
+    nMinute = FloatToInt(fMinute) / 60;
+    nSecond = FloatToInt(fMinute) - (nMinute * 60);
+
+    sTime = DeleteListItem(sTime, 5);
+    sTime = DeleteListItem(sTime, 4);
+    sTime = AddListItem(sTime, IntToString(nMinute));
+    return  AddListItem(sTime, IntToString(nSecond));
+}
+
+string ConvertSystemTimeToGameTime(string sTime = TIME_INVALID)
+{
+    string debug = "ConvertSystemTimeToGameTime :: ";
+
+    if (sTime == TIME_INVALID)
+        sTime = CreateSystemTimeVector();
+    else if (CountList(sTime) != SYSTEM_ELEMENTS)
+    {
+        Error(debug + "The passed time argument did not contain the correct number " +
+                " of time elements." +
+                "\n   sTime = " + sTime);
+        return TIME_INVALID;
+    }
+
+    int nMinute, nSecond;
+    float fMinute;
+
+    nMinute = StringToInt(GetListItem(sTime, 4));
+    nSecond = StringToInt(GetListItem(sTime, 5));
+    fMinute = (nMinute * 60.0 + nSecond) / (HoursToSeconds(1) / 60.0);
+    nSecond = FloatToInt(frac(fMinute) * 60.0);
+    nMinute = FloatToInt(fMinute);
+    
+    sTime = DeleteListItem(sTime, 5);
+    sTime = DeleteListItem(sTime, 4);
+
+    sTime = AddListItem(sTime, IntToString(nMinute));
+    return  AddListItem(sTime, IntToString(nSecond));
+    return sTime;
+}
+
+float ConvertSystemTimeTo(int nElement, string sTime = TIME_INVALID)
+{
+    sTime = ConvertSystemTimeToGameTime(sTime);
+    string sSeconds = _ConvertGameTimeToSecondsVector(sTime, VECTOR_TIME);
+    return _ConvertSecondsVectorTo(nElement, sSeconds);
+}
+
+float ConvertGameTimeTo(int nElement, string sTime = TIME_INVALID)
+{
+    string sSeconds = _ConvertGameTimeToSecondsVector(sTime, VECTOR_TIME);
+    return _ConvertSecondsVectorTo(nElement, sSeconds);
+}
+
+float ConvertDifferenceVectorTo(int nElement, string sTime = TIME_INVALID)
+{
+    string sSeconds = _ConvertGameTimeToSecondsVector(sTime, VECTOR_DIFFERENCE);
+    return _ConvertSecondsVectorTo(nElement, sSeconds);
+}
+
+float GetSystemTimeDifferenceIn(int nElement, string sTime1, string sTime2 = TIME_INVALID)
+{
+    string sSeconds = _GetTimeDifference(sTime1, sTime2, MODE_SYSTEM, RETURN_SECONDS);
+    return _ConvertSecondsVectorTo(nElement, sSeconds, MODE_SYSTEM);
+}
+
+float GetGameTimeDifferenceIn(int nElement, string sTime1, string sTime2 = TIME_INVALID)
+{
+    string sSeconds = _GetTimeDifference(sTime1, sTime2, MODE_GAME, RETURN_SECONDS);
+    return _ConvertSecondsVectorTo(nElement, sSeconds, MODE_GAME);
+}
+
+string FormatGameTime(string sFormat = DEFAULT_FORMAT, string sTime = TIME_INVALID)
+{
+    if (sTime == TIME_INVALID || sTime == "")
+        sTime = GetGameTime();
+    else if ((sTime = _ValidateTime(sTime, MODE_GAME)) == TIME_INVALID)
+        return TIME_INVALID;
+
+    if (GetStringLength(sFormat) == 0)
+        sFormat = DEFAULT_FORMAT;
+
+    int nIndex;
+    string s, sElementFormat, sFormattedTime;
+
+    while (GetStringLength(sFormat) > 0)
+    {
+        s = GetStringLeft(sFormat, 1);
+        sElementFormat = s;
+        sFormat = GetStringRight(sFormat, GetStringLength(sFormat) - 1);
+
+        while (GetStringLeft(sFormat, 1) == s)
+        {
+            sElementFormat += s;
+            sFormat = GetStringRight(sFormat, GetStringLength(sFormat) - 1);
+        }
+
+        nIndex = 0;
+        if (FindListItem(FORMAT_ELEMENTS, s) == -1)
+            sFormattedTime += s;
+        else if (s == "h" || s == "H" || s == "t")
+            nIndex = TIME_HOURS;
+        else
+            nIndex = FindListItem(FORMAT_ELEMENTS, s);
+
+        if (nIndex || s == "y")
+            sFormattedTime += _FormatTimeElement(GetListItem(sTime, nIndex), sElementFormat);
+    }
+
+    return sFormattedTime;
+}
+
+string FormatSystemTime(string sFormat = DEFAULT_FORMAT, string sTime = TIME_INVALID)
+{
+    if (sTime == TIME_INVALID || sTime == "")
+        sTime = GetSystemTime();
+    else if ((sTime = _ValidateTime(sTime, MODE_SYSTEM)) == TIME_INVALID)
+        return TIME_INVALID;
+ 
+    sTime = ConvertSystemTimeToGameTime(sTime);
+    return FormatGameTime(sFormat, sTime);
+}
+
+string GetPrecisionSystemTime(int nPrecision = TIME_SECONDS, string sTime = TIME_INVALID)
+{
+    if (sTime == TIME_INVALID || sTime == "")
+        sTime = _CreateTimeVector(MODE_SYSTEM, VECTOR_TIME);
+
+    return _GetPrecisionTime(sTime, nPrecision);
+}
+
+string GetPrecisionGameTime(int nPrecision = TIME_SECONDS, string sTime = TIME_INVALID)
+{
+    if (sTime == TIME_INVALID || sTime == "")
+        sTime == _CreateTimeVector(MODE_GAME, VECTOR_TIME);
+
+    return _GetPrecisionTime(sTime, nPrecision);
+}
+
+int IsLeapYear(int nYear)
+{
+    return ((nYear % 4 == 0 && nYear % 100 != 0) || nYear % 400 == 0);
+}
+
+string GetFormattedTimeSinceEpoch(int nSeconds, string sFormat = DEFAULT_FORMAT)
+{
+    if (nSeconds < 0)
+        return TIME_INVALID;
+
+    int DaysPerLYPeriod = 146097;
+    int YearsPerLYPeriod = 400;
+    int SecondsPerDay = 86400;
+    int DaysPerYear = 365;
+    int DaysPerLeapYear = 366;
+    string sMonth = "0,31,59,90,120,151,181,212,243,273,304,334";
+    string sLeapMonths = "-1,30,59,90,120,151,181,212,243,273,304,334";
+    string sMonths;
+
+    int nMonth, nTempDays, nYear = 1970;
+    float fDays = nSeconds / IntToFloat(SecondsPerDay);
+    float fDaysRemainder = frac(fDays);
+
+    nTempDays = FloatToInt(fDays + 1);
+    if (nTempDays >= DaysPerLYPeriod)
+    {
+        nYear += YearsPerLYPeriod * (nTempDays / DaysPerLYPeriod);
+        fDays -= DaysPerLYPeriod * (nTempDays / DaysPerLYPeriod);
+    }    
+
+    while (nTempDays >= DaysPerLeapYear)
+    {
+        nYear++;
+        if (IsLeapYear(nYear))
+            nTempDays -= DaysPerLeapYear;
+        else
+            nTempDays -= DaysPerYear;
+    }
+
+    sMonths = IsLeapYear(nYear) ? sLeapMonths : sMonths;
+    if (IsLeapYear(nYear) && nYear < 1970)
+        nTempDays--;
+
+    nMonth = 11;
+    while (nMonth > 0)
+    {
+        if (nTempDays > StringToInt(GetListItem(sMonths, nMonth)))
+            break;
+
+        nMonth--;
+    }
+
+    nTempDays -= StringToInt(GetListItem(sMonths, nMonth));
+
+    int nHours = FloatToInt(IntToFloat(nSeconds/60/60)) % 24;
+    int nMinutes = FloatToInt(IntToFloat(nSeconds/60)) % 60;
+    int nSecs = nSeconds % 60;
+
+    string sTime = AddListItem(sTime, IntToString(nYear));
+    sTime = AddListItem(sTime, IntToString(nMonth + 1));
+    sTime = AddListItem(sTime, IntToString(nTempDays));
+    sTime = AddListItem(sTime, IntToString(nHours));
+    sTime = AddListItem(sTime, IntToString(nMinutes));
+    sTime = AddListItem(sTime, IntToString(nSecs));
+
+    int nIndex;
+    string s, sElementFormat, sFormattedTime;
+
+    while (GetStringLength(sFormat) > 0)
+    {
+        s = GetStringLeft(sFormat, 1);
+        sElementFormat = s;
+        sFormat = GetStringRight(sFormat, GetStringLength(sFormat) - 1);
+
+        while (GetStringLeft(sFormat, 1) == s)
+        {
+            sElementFormat += s;
+            sFormat = GetStringRight(sFormat, GetStringLength(sFormat) - 1);
+        }
+
+        nIndex = 0;
+        if (FindListItem(FORMAT_ELEMENTS, s) == -1)
+            sFormattedTime += s;
+        else if (s == "h" || s == "H" || s == "t")
+            nIndex = TIME_HOURS;
+        else
+            nIndex = FindListItem(FORMAT_ELEMENTS, s);
+
+        if (nIndex || s == "y")
+            sFormattedTime += _FormatTimeElement(GetListItem(sTime, nIndex), sElementFormat);
+    }
+
+    return sFormattedTime;
+}

--- a/src/utils/util_i_time.nss
+++ b/src/utils/util_i_time.nss
@@ -1241,5 +1241,3 @@ string GetFormattedTimeSinceEpoch(int nSeconds, string sFormat = DEFAULT_FORMAT,
 
     return sFormattedTime;
 }
-
-void main() {}


### PR DESCRIPTION
Add `util_i_time` to the utilities family.  This utility provides for string based comparison of "time vectors", which are 6-element comma-delimited lists representing year, month, day, hour, minute, second.  Times are stored as strings, but manipulated as numbers.  This methodology prevents overflow of the 32-bit integer type and loss of precision in the float type.  These functions have been tested for all valid years in the game (0 - 30000).  Documentation and examples are provided in `time.md`.  Time retrieval, comparison and conversion functions are included, as well as others.  Additionally, there are some other basic functions for retrieving a weekday name, month name, setting server time, etc.

Recently added is a function to format a unix timestamp (usually sourced from NWNX_Time_GetTimeStamp) into a date/time string of any format created with standard formatting strings.