### PR TITLE
added string uncolor function before sending to game log

### DIFF
--- a/src/utils/util_i_debug.nss
+++ b/src/utils/util_i_debug.nss
@@ -227,7 +227,7 @@ void Debug(string sMessage, int nLevel = DEBUG_LEVEL_DEBUG, object oTarget = OBJ
         int nLogging = GetLocalInt(GetModule(), DEBUG_LOG);
 
         if (nLogging & DEBUG_LOG_FILE)
-            WriteTimestampedLogEntry(sMessage);
+            WriteTimestampedLogEntry(UnColorString(sMessage));
 
         sMessage = ColorString(sMessage, sColor);
 


### PR DESCRIPTION
... to prevent a bunch of color codes being printed to the game's log.  Currently condition prints color codes to the game's log when using colored strings for debug purposes.