### PR TITLE
skip trigger event for non-transition triggers

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -986,6 +986,8 @@ void HookObjectEvents(object oObject, int bSkipHeartbeat = TRUE, int bStoreOldEv
                 nEnd   = EVENT_SCRIPT_TRIGGER_ON_CLICKED;
                 if (bSkipHeartbeat)
                     nStart++;
+                if (JsonPointer(ObjectToJson(oObject), "/LinkedTo/value") == JsonString(""))
+                    nEnd--;
                 break;
             case OBJECT_TYPE_STORE:
                 nStart = EVENT_SCRIPT_STORE_ON_OPEN;


### PR DESCRIPTION
Fix for #45 - it's a big ugly code-scar in the function, but it works to prevent changing the behavior of a generic trigger to a transition trigger.  `GetTransitionTarget` would not work because it would return `OBJECT_INVALID` for valid transitions if the object didn't exist (yet), therefore preventing hooking the event if desired by the user.  The current method of using the json `LinkedTo` object checks to see whether a target has been set at all, even if it's invalid.  Doors may exhibit similar hard-coded behavior (auto-transition when adding an event script to `OnClicked`), but I'll have to do some testing before modifying the code for doors.