### PR TITLE
Plugin event|library script registration via funtion decorator

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -34,6 +34,34 @@ game events for the module, AoEs, areas, doors, encounters, placeables, stores,
 triggers, traps, and creatures. PCs also have their own creature events that use
 the prefix `OnPC*` instead of `OnCreature*`.
 
+Scripts can also be registered using the `RegisterPluginScripts()` function.
+This function takes the [object to register the script on](#script-sources) and
+a CSV list of glob patterns matching nss filenames.  This function requires
+a specified decorator be applied to each event script in a script library.
+The decorator must reside in a comment immediately preceding the specific
+function and must contain the following:
+
+- Decorator (required):  `@EVENT[...]`
+- Event Reference (required):  `OnModuleLoad`
+- [Priority](#script-priorities) (optional)
+
+Example decorators:
+
+```c
+// @EVENT[OnModuleLoad:first]
+void pw_OnModuleLoad() {...}
+
+// @EVENT[OnPlayerDeath]
+void pw_OnPlayerDeath() {...}
+
+// @EVENT[OnPlayerChat:3.0]
+void pw_OnPlayerChat() {...}
+```
+
+While registering scripts decorated with `@EVENT[...]`, `RegisterPluginScripts()`
+will also register any library scripts decorated with `@LIBRARY[]` in script
+libraries matching the given glob patterns.
+
 ## Script Sources
 Since scripts are not placed directly into an object's event script slots, the
 framework needs to know what scripts should be run for an event. There are


### PR DESCRIPTION
Yet another extension to reduce workload for creating a plugin.  This function takes a CSV list of patterns, pulls the matching `.nss` files, scans the contents for specified decorators `@EVENT[...]` and, optionally, `@LIBRARY[]`, and registers the event and library scripts scripts for that plugin.

1) Tested to work as intended as long as the decorator is in a comment immediately before the function definition.  Can theoretically be used in function prototypes, but hasn't been tested there.

2) Had to revert to calling `AddLibraryScript` directly (vs `RegisterLibraryScript`) because of issues with `SetScriptParam` not passing the correct library for the current VM session, so the library script overwrite notifications are bypassed.  Let me know if you have a better way to implement this.

3) The lines are bit a long due to the nature of regex and `JsonPointer` addressing.  I shortened them quite a bit with `SubstituteString`, but they're still a bit abnormally lengthy.

4) Could possibly add another regex capture group to prevent a second scan of the document for the different decorators, but I'll leave that for commenting.  I left them separate for now given how different the regex constructs are between the two decorators.