### PR TITLE
Automatically activate discovered plugins during framework initialization

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -120,7 +120,9 @@ const int INITIALIZATION_DEBUG_LEVEL = DEBUG_LEVEL_DEBUG;
 const string INSTALLED_LIBRARIES = "*_l_plugin";
 
 /// This is a comma-separated list of plugins that should be activated when the
-/// Core Framework is initialized.
+/// Core Framework is initialized.  If this list is empty, all plugins discovered
+/// in INSTALLED_LIBRARIES above will be automatically activated.  If plugins
+/// are specified here, *only* the listed plugins will be activated.
 const string INSTALLED_PLUGINS = "";
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Pretty much what the title says.  If `INSTALLED_PLUGINS` remains an empty string, any plugins discovered during library loading are automatically activated.  If plugins are specified, auto-activation does not occur and only the specified plugins are activated.