### PR TITLE
add default scripts into HookObjectEvents()

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -939,13 +939,38 @@ void HookObjectEvent(object oObject, int nEvent, int bStoreOldEvent = TRUE)
 {
     string sScript = GetEventScript(oObject, nEvent);
     SetEventScript(oObject, nEvent, CORE_HOOK_NWN);
+
+    if (sScript == "" || sScript == "default")
+    {
+        switch (nEvent)
+        {
+            case EVENT_SCRIPT_DOOR_ON_TRAPTRIGGERED:
+            case EVENT_SCRIPT_PLACEABLE_ON_TRAPTRIGGERED:
+            case EVENT_SCRIPT_TRIGGER_ON_TRAPTRIGGERED:
+                sScript = Get2DAString("traps", "TrapScript", GetTrapBaseType(oObject));
+                if (sScript != "")
+                    sScript = GetStringLowerCase(sScript + ":default");
+                break;
+            case EVENT_SCRIPT_CREATURE_ON_DIALOGUE:
+            case EVENT_SCRIPT_DOOR_ON_DIALOGUE:
+            case EVENT_SCRIPT_PLACEABLE_ON_DIALOGUE:
+                sScript = "nw_g0_conversat:default"; break;
+            case EVENT_SCRIPT_DOOR_ON_CLICKED:
+            case EVENT_SCRIPT_TRIGGER_ON_CLICKED:
+                sScript = "nw_g0_transition:default"; break;
+        }
+
+        if (sScript != "")
+            bStoreOldEvent = TRUE;
+    }
+
     if (!bStoreOldEvent || sScript == "" || sScript == CORE_HOOK_NWN)
         return;
 
     string sEvent = GetEventName(nEvent);
     if (GetIsPC(oObject) && GetStringLeft(sEvent, 10) == "OnCreature")
         sEvent = ReplaceSubString(sEvent, "OnPC", 0, 9);
-    AddLocalListItem(oObject, sEvent, sScript);
+    AddLocalListItem(oObject, sEvent, sScript, TRUE);
 }
 
 void HookObjectEvents(object oObject, int bSkipHeartbeat = TRUE, int bStoreOldEvents = TRUE)

--- a/src/demo/bw_defaultevents.uti.json
+++ b/src/demo/bw_defaultevents.uti.json
@@ -286,7 +286,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "nw_c2_default4,nw_g0_conversat:default"
+          "value": "nw_c2_default4"
         }
       },
       {
@@ -437,66 +437,6 @@
         "Value": {
           "type": "cexostring",
           "value": "nw_c2_defaultd"
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "OnPlaceableConversation"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 3
-        },
-        "Value": {
-          "type": "cexostring",
-          "value": "nw_g0_conversat:default"
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "OnDoorConversation"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 3
-        },
-        "Value": {
-          "type": "cexostring",
-          "value": "nw_g0_conversat:default"
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "OnDoorAreaTransitionClick"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 3
-        },
-        "Value": {
-          "type": "cexostring",
-          "value": "nw_g0_transition:default"
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "OnTriggerClick"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 3
-        },
-        "Value": {
-          "type": "cexostring",
-          "value": "nw_g0_transition:default"
         }
       }
     ]

--- a/src/demo/bw_defaultevents.uti.json
+++ b/src/demo/bw_defaultevents.uti.json
@@ -286,7 +286,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "nw_c2_default4, nw_g0_conversat:default"
+          "value": "nw_c2_default4,nw_g0_conversat:default"
         }
       },
       {
@@ -467,6 +467,36 @@
         "Value": {
           "type": "cexostring",
           "value": "nw_g0_conversat:default"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "OnDoorAreaTransitionClick"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "nw_g0_transition:default"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "OnTriggerClick"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "nw_g0_transition:default"
         }
       }
     ]


### PR DESCRIPTION
To remedy a situation where objects with default scripts, specifically objects with transitions, quit working after being hooked by the framework, I added the default scripts into `HookObjectEvent().`

The reason all of the default scripts are included here, including `nw_g0_conversat` and `nw_g0_transition`, even though they are included as variables on the `bw_defaultevents` plugin item, is because this behavior is mandatory to ensure the transitions and conversations work correctly, while the inclusion of the `bw_defaultevents` item is not mandatory as it's part of the framework demo and not the core.  The idea here is that system should still run correctly if no files from folders other than `core` are included.

I also added the `nw_g0_transition:default` script to the appropriate events on `bw_defaultevents.uti`.

Finally, I wasn't creative enough to find a way to add default `OnTrapTriggered` behavior (2da lookup) to the `bw_defaultevents` item, so that functionality only exists in `HookObjectEvent()`.