### PR TITLE
config: add logfile debug level constant and setting

### DIFF
--- a/src/core/core_c_config.nss
+++ b/src/core/core_c_config.nss
@@ -102,6 +102,13 @@ const int PERCEPTION_DEBUG_LEVEL = DEBUG_LEVEL_ERROR;
 /// DEFAULT_DEBUG_LEVEL
 const int INITIALIZATION_DEBUG_LEVEL = DEBUG_LEVEL_DEBUG;
 
+/// This is the level of debug messages to generate when the debug message will
+/// be sent to the game's logfile.  Debug messages that qualify at this
+/// debug level will be sent to the game's log, regardless of the debug level
+/// set on a specific object or DEFAULT_DEBUG_LEVEL above.  If DEBUG_LOG_FILE
+/// is not included in DEBUG_LOGGING above, this value will be ignored.
+const int LOGFILE_DEBUG_LEVEL = DEFAULT_DEBUG_LEVEL;
+
 // -----------------------------------------------------------------------------
 //                         Library and Plugin Management
 // -----------------------------------------------------------------------------

--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -322,6 +322,7 @@ void InitializeCoreFramework()
     // Start debugging
     SetDebugLevel(INITIALIZATION_DEBUG_LEVEL, oModule);
     SetDebugLogging(DEBUG_LOGGING);
+    SetLogfileDebugLevel(LOGFILE_DEBUG_LEVEL);
     SetDebugPrefix(HexColorString("[Module]",  COLOR_CYAN), oModule);
     SetDebugPrefix(HexColorString("[Events]",  COLOR_CYAN), EVENTS);
     SetDebugPrefix(HexColorString("[Plugins]", COLOR_CYAN), PLUGINS);


### PR DESCRIPTION
This change adds support to logfile debug levels, including a setting in the framework configuration file.  Should not be integrated  before squattingmonk/sm-utils#43.