### PR TITLE
initialize: update code to use object filter in `GetFirst|NextObjectInArea`

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -304,14 +304,12 @@ void InitializeCoreFramework()
 
             if (AUTO_HOOK_OBJECT_EVENTS)
             {
-                // Once .35 is released, we can use the nObjectFilter parameter.
-                object oObject = GetFirstObjectInArea(oArea);
+                object oObject = GetFirstObjectInArea(oArea, AUTO_HOOK_OBJECT_EVENTS);
                 while (GetIsObjectValid(oObject))
                 {
-                    int nType = GetObjectType(oObject);
-                    if (AUTO_HOOK_OBJECT_EVENTS & nType && !GetLocalInt(oObject, SKIP_AUTO_HOOK))
-                        HookObjectEvents(oObject, !(AUTO_HOOK_OBJECT_HEARTBEAT_EVENT & nType));
-                    oObject = GetNextObjectInArea(oArea);
+                    if (!GetLocalInt(oObject, SKIP_AUTO_HOOK))
+                        HookObjectEvents(oObject, !(AUTO_HOOK_OBJECT_HEARTBEAT_EVENT & GetObjectType(oObject)));
+                    oObject = GetNextObjectInArea(oArea, AUTO_HOOK_OBJECT_EVENTS);
                 }
             }
 


### PR DESCRIPTION
Minor update to remove the comment about updating once .35 is stable, consdiering we're up to .37-14 now, with .38 on preview.  Basic testing complete (this is, it compiles and appears to work with my test module), not extensively tested, so beware of goblins.