### PR TITLE
framework: incorporate .37 nwnx availability check and error reporting into event script registration process

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -582,8 +582,21 @@ void RegisterEventScript(object oTarget, string sEvent, string sScripts, float f
     // Handle NWNX script registration.
     if (GetStringLeft(sEvent, 4) == "NWNX")
     {
-        SetScriptParam(EVENT_NAME, sEvent);
-        ExecuteScript(CORE_HOOK_NWNX);
+        if (NWNXGetIsAvailable())
+        {
+            SetScriptParam(EVENT_NAME, sEvent);
+            ExecuteScript(CORE_HOOK_NWNX);
+        }
+        else
+        {
+            CriticalError("Could not register scripts: " +
+                "\n    Source: " + sTarget +
+                "\n    Event: " + sEvent +
+                "\n    Scripts: " + sScripts +
+                "\n    Priority: " + sPriority +
+                "\n    Error: NWNX:EE not available", oTarget);
+            return;
+        }
     }
 
     int i, nCount = CountList(sScripts);
@@ -592,7 +605,7 @@ void RegisterEventScript(object oTarget, string sEvent, string sScripts, float f
         string sScript = GetListItem(sScripts, i);
         if (IsDebugging(DEBUG_LEVEL_DEBUG))
         {
-            Debug("Registering event script :" +
+            Debug("Registering event script:" +
                 "\n    Source: " + sTarget + " (" + GetName(oTarget) + " [" + GetTag(oTarget) + "])" +
                 "\n    Event: " + sEvent +
                 "\n    Script: " + sScript +


### PR DESCRIPTION
The most recent stable (.37-14+) has incorporated NWNX called directly into `nwscript.nss`.  This change carries with it a complete script abort if nwnx is called, but not available.  Therefore, during the script registration process, if an nwnx event script is registered and nwnx is not currently running, as may be the case with local testing, the entire library script that is attempting to register that event will be aborted.

There is expected to be a ruleset toggle that prevent this behavior and allows the script to continue while providing an error, however, the toggle will default to script abort, which means we need to take the most conservative route and ensure our libraries aren't aborted because of the lack of nwnx availability.

In addition to the check, an error message is provided to ensure the user understands exactly why the script was not registered.

I didn't swe a threat in `hook_nwnx` that would require this change to be incorporated there since it's only run via NWNX or `ExecuteScript` from the framework after the availability check, so worst case, it would simply fail with a transmitted error.  However, if youw want full coverage, `hook_nwnx` may also be modified to include this check.

With this change, .37-14+ is the required minimum game version for the framework.