### PR TITLE
fix: missing debug level in IsDebugging function call

### DIFF
--- a/src/core/core_i_framework.nss
+++ b/src/core/core_i_framework.nss
@@ -769,7 +769,7 @@ int RunEvent(string sEvent, object oInit = OBJECT_INVALID, object oSelf = OBJECT
         if (nExecuted++ && fPriority == EVENT_PRIORITY_DEFAULT)
             break;
 
-        if (IsDebugging)
+        if (IsDebugging(DEBUG_LEVEL_DEBUG))
         {
             Debug("Executing event script " + sScript + " from " +
                 GetDebugPrefix(StringToObject(sSource)) + " with a priority of " +


### PR DESCRIPTION
Not sure how this one got through, but missing a debug level in the `IsDebugging` call in the core framework file.